### PR TITLE
update(services): simplify Soluciones into Stripe-style stacked cards

### DIFF
--- a/src/features/home/components/services.astro
+++ b/src/features/home/components/services.astro
@@ -23,7 +23,7 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
     <div class="flex flex-col gap-6 md:gap-8">
         <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[20rem] md:min-h-[22rem] text-emerald-50 transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
             <div class="services-mesh services-mesh--primary absolute inset-0 -z-10"></div>
-            <CodeXml class="absolute right-8 md:right-12 bottom-8 md:bottom-12 w-40 h-40 md:w-52 md:h-52 text-white/[0.07] -z-10" stroke-width={1} />
+            <div class="services-pattern services-pattern--stripes absolute inset-0 -z-10"></div>
             <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
                 <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-white/15 backdrop-blur-sm">
                     <CodeXml class="w-6 h-6 text-white" stroke-width="1.5" />
@@ -39,7 +39,7 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
 
         <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[20rem] md:min-h-[22rem] transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
             <div class="services-mesh services-mesh--mint absolute inset-0 -z-10"></div>
-            <Zap class="absolute right-8 md:right-12 bottom-8 md:bottom-12 w-40 h-40 md:w-52 md:h-52 text-emerald-900/[0.06] -z-10" stroke-width={1} />
+            <div class="services-pattern services-pattern--waves absolute inset-0 -z-10"></div>
             <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
                 <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-white/70 backdrop-blur-sm text-emerald-700">
                     <Zap class="w-6 h-6" stroke-width="1.5" />
@@ -55,7 +55,7 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
 
         <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[20rem] md:min-h-[22rem] transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
             <div class="services-mesh services-mesh--sand absolute inset-0 -z-10"></div>
-            <ChartBar class="absolute right-8 md:right-12 bottom-8 md:bottom-12 w-40 h-40 md:w-52 md:h-52 text-emerald-900/[0.06] -z-10" stroke-width={1} />
+            <div class="services-pattern services-pattern--dots absolute inset-0 -z-10"></div>
             <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
                 <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-white/70 backdrop-blur-sm text-emerald-700">
                     <ChartBar class="w-6 h-6" stroke-width="1.5" />
@@ -95,5 +95,32 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
         background-image:
             radial-gradient(ellipse 65% 60% at 5% 0%, hsla(160, 60%, 92%, 0.6) 0%, transparent 75%),
             radial-gradient(ellipse 70% 60% at 95% 100%, hsla(200, 55%, 92%, 0.45) 0%, transparent 75%);
+    }
+
+    .services-pattern {
+        pointer-events: none;
+        -webkit-mask-image: radial-gradient(ellipse 75% 80% at 100% 100%, black 0%, transparent 70%);
+        mask-image: radial-gradient(ellipse 75% 80% at 100% 100%, black 0%, transparent 70%);
+    }
+
+    .services-pattern--stripes {
+        background-image: repeating-linear-gradient(
+            45deg,
+            rgba(255, 255, 255, 0.09) 0,
+            rgba(255, 255, 255, 0.09) 1px,
+            transparent 1px,
+            transparent 12px
+        );
+    }
+
+    .services-pattern--waves {
+        background-image: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 40' preserveAspectRatio='none'%3E%3Cpath d='M0 20 Q 50 0 100 20 T 200 20' fill='none' stroke='%23047857' stroke-width='1.2' opacity='0.22'/%3E%3C/svg%3E");
+        background-size: 180px 36px;
+        background-repeat: repeat;
+    }
+
+    .services-pattern--dots {
+        background-image: radial-gradient(circle, rgba(4, 120, 87, 0.22) 1.4px, transparent 1.6px);
+        background-size: 18px 18px;
     }
 </style>

--- a/src/features/home/components/services.astro
+++ b/src/features/home/components/services.astro
@@ -21,52 +21,49 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
     </div>
 
     <div class="flex flex-col gap-6 md:gap-8">
-        <article class="services-card services-card--primary relative overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[26rem] md:min-h-[30rem] bg-emerald-700 text-emerald-100 transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
-            <div class="services-dots services-dots--light absolute inset-0"></div>
-            <div class="absolute -bottom-24 -right-16 w-[28rem] h-[28rem] rounded-full bg-emerald-300/30 blur-3xl"></div>
-            <CodeXml class="absolute right-6 md:right-10 bottom-6 md:bottom-10 w-48 h-48 md:w-64 md:h-64 text-emerald-100/10" stroke-width={1} />
+        <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[26rem] md:min-h-[30rem] text-emerald-50 transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
+            <div class="services-mesh services-mesh--primary absolute inset-0 -z-10"></div>
+            <CodeXml class="absolute right-6 md:right-10 bottom-6 md:bottom-10 w-48 h-48 md:w-64 md:h-64 text-white/10 -z-10" stroke-width={1} />
             <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
-                <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-emerald-100/15">
-                    <CodeXml class="w-6 h-6 text-emerald-100" stroke-width="1.5" />
+                <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-white/15 backdrop-blur-sm">
+                    <CodeXml class="w-6 h-6 text-white" stroke-width="1.5" />
                 </div>
-                <h3 class="text-2xl md:text-3xl lg:text-4xl font-semibold leading-tight">
+                <h3 class="text-2xl md:text-3xl lg:text-4xl font-semibold leading-tight text-white">
                     Software a medida
                 </h3>
-                <p class="text-emerald-100/80 text-base md:text-lg leading-relaxed">
+                <p class="text-emerald-50/85 text-base md:text-lg leading-relaxed">
                     Soluciones personalizadas que se adaptan a los procesos únicos de tu negocio.
                 </p>
             </div>
         </article>
 
-        <article class="services-card relative overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[26rem] md:min-h-[30rem] bg-emerald-50/70 transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
-            <div class="services-dots services-dots--dark absolute inset-0"></div>
-            <div class="absolute -top-20 -right-20 w-[24rem] h-[24rem] rounded-full bg-emerald-300/40 blur-3xl"></div>
-            <Zap class="absolute right-6 md:right-10 bottom-6 md:bottom-10 w-48 h-48 md:w-64 md:h-64 text-emerald-700/10" stroke-width={1} />
+        <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[26rem] md:min-h-[30rem] transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
+            <div class="services-mesh services-mesh--mint absolute inset-0 -z-10"></div>
+            <Zap class="absolute right-6 md:right-10 bottom-6 md:bottom-10 w-48 h-48 md:w-64 md:h-64 text-emerald-800/10 -z-10" stroke-width={1} />
             <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
-                <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-emerald-100 text-emerald-700">
+                <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-white/70 backdrop-blur-sm text-emerald-700">
                     <Zap class="w-6 h-6" stroke-width="1.5" />
                 </div>
-                <h3 class="text-2xl md:text-3xl lg:text-4xl font-semibold leading-tight text-zinc-800">
+                <h3 class="text-2xl md:text-3xl lg:text-4xl font-semibold leading-tight text-zinc-900">
                     Automatización
                 </h3>
-                <p class="text-zinc-600 text-base md:text-lg leading-relaxed">
+                <p class="text-zinc-700 text-base md:text-lg leading-relaxed">
                     Flujos automatizados que eliminan trabajo repetitivo y reducen errores.
                 </p>
             </div>
         </article>
 
-        <article class="services-card relative overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[26rem] md:min-h-[30rem] bg-zinc-50 transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
-            <div class="services-dots services-dots--dark absolute inset-0"></div>
-            <div class="absolute -bottom-24 -left-16 w-[26rem] h-[26rem] rounded-full bg-emerald-200/50 blur-3xl"></div>
-            <ChartBar class="absolute right-6 md:right-10 bottom-6 md:bottom-10 w-48 h-48 md:w-64 md:h-64 text-emerald-700/10" stroke-width={1} />
+        <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[26rem] md:min-h-[30rem] transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
+            <div class="services-mesh services-mesh--sand absolute inset-0 -z-10"></div>
+            <ChartBar class="absolute right-6 md:right-10 bottom-6 md:bottom-10 w-48 h-48 md:w-64 md:h-64 text-emerald-800/10 -z-10" stroke-width={1} />
             <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
-                <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-emerald-100 text-emerald-700">
+                <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-white/70 backdrop-blur-sm text-emerald-700">
                     <ChartBar class="w-6 h-6" stroke-width="1.5" />
                 </div>
-                <h3 class="text-2xl md:text-3xl lg:text-4xl font-semibold leading-tight text-zinc-800">
+                <h3 class="text-2xl md:text-3xl lg:text-4xl font-semibold leading-tight text-zinc-900">
                     Consultoría estratégica
                 </h3>
-                <p class="text-zinc-600 text-base md:text-lg leading-relaxed">
+                <p class="text-zinc-700 text-base md:text-lg leading-relaxed">
                     Análisis y roadmap técnico para priorizar lo que mueve la aguja de tu negocio.
                 </p>
             </div>
@@ -75,19 +72,40 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
 </section>
 
 <style>
-    .services-dots {
-        background-image: radial-gradient(circle, currentColor 1px, transparent 1px);
-        background-size: 22px 22px;
-        -webkit-mask-image: radial-gradient(ellipse 70% 70% at 80% 80%, black 0%, transparent 70%);
-        mask-image: radial-gradient(ellipse 70% 70% at 80% 80%, black 0%, transparent 70%);
+    .services-mesh {
         pointer-events: none;
     }
 
-    .services-dots--light {
-        color: rgba(209, 250, 229, 0.18);
+    .services-mesh--primary {
+        background-color: #022c22;
+        background-image:
+            radial-gradient(at 18% 22%, hsla(160, 84%, 45%, 0.65) 0px, transparent 55%),
+            radial-gradient(at 88% 12%, hsla(178, 78%, 42%, 0.55) 0px, transparent 55%),
+            radial-gradient(at 72% 88%, hsla(94, 70%, 55%, 0.45) 0px, transparent 55%),
+            radial-gradient(at 12% 78%, hsla(165, 96%, 24%, 0.85) 0px, transparent 60%),
+            radial-gradient(at 96% 52%, hsla(150, 80%, 38%, 0.55) 0px, transparent 55%),
+            radial-gradient(at 40% 50%, hsla(175, 80%, 32%, 0.45) 0px, transparent 55%);
     }
 
-    .services-dots--dark {
-        color: rgba(4, 120, 87, 0.12);
+    .services-mesh--mint {
+        background-color: #f0fdf4;
+        background-image:
+            radial-gradient(at 16% 24%, hsla(160, 90%, 76%, 0.7) 0px, transparent 55%),
+            radial-gradient(at 90% 12%, hsla(178, 82%, 80%, 0.65) 0px, transparent 55%),
+            radial-gradient(at 78% 92%, hsla(95, 86%, 78%, 0.6) 0px, transparent 55%),
+            radial-gradient(at 8% 82%, hsla(168, 80%, 78%, 0.6) 0px, transparent 55%),
+            radial-gradient(at 96% 58%, hsla(35, 92%, 86%, 0.55) 0px, transparent 55%),
+            radial-gradient(at 42% 48%, hsla(160, 100%, 92%, 0.7) 0px, transparent 55%);
+    }
+
+    .services-mesh--sand {
+        background-color: #fafafa;
+        background-image:
+            radial-gradient(at 82% 8%, hsla(160, 70%, 86%, 0.7) 0px, transparent 55%),
+            radial-gradient(at 6% 42%, hsla(200, 75%, 88%, 0.6) 0px, transparent 55%),
+            radial-gradient(at 82% 96%, hsla(150, 88%, 84%, 0.65) 0px, transparent 55%),
+            radial-gradient(at 4% 6%, hsla(35, 76%, 92%, 0.55) 0px, transparent 55%),
+            radial-gradient(at 96% 52%, hsla(175, 82%, 90%, 0.6) 0px, transparent 55%),
+            radial-gradient(at 48% 60%, hsla(155, 70%, 94%, 0.7) 0px, transparent 55%);
     }
 </style>

--- a/src/features/home/components/services.astro
+++ b/src/features/home/components/services.astro
@@ -23,7 +23,7 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
     <div class="flex flex-col gap-6 md:gap-8">
         <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[20rem] md:min-h-[22rem] text-emerald-50 transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
             <div class="services-mesh services-mesh--primary absolute inset-0 -z-10"></div>
-            <div class="services-pattern services-pattern--stripes absolute inset-0 -z-10"></div>
+            <div class="services-pattern services-pattern--light absolute inset-0 -z-10"></div>
             <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
                 <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-white/15 backdrop-blur-sm">
                     <CodeXml class="w-6 h-6 text-white" stroke-width="1.5" />
@@ -39,7 +39,7 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
 
         <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[20rem] md:min-h-[22rem] transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
             <div class="services-mesh services-mesh--mint absolute inset-0 -z-10"></div>
-            <div class="services-pattern services-pattern--waves absolute inset-0 -z-10"></div>
+            <div class="services-pattern services-pattern--dark absolute inset-0 -z-10"></div>
             <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
                 <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-white/70 backdrop-blur-sm text-emerald-700">
                     <Zap class="w-6 h-6" stroke-width="1.5" />
@@ -55,7 +55,7 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
 
         <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[20rem] md:min-h-[22rem] transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
             <div class="services-mesh services-mesh--sand absolute inset-0 -z-10"></div>
-            <div class="services-pattern services-pattern--dots absolute inset-0 -z-10"></div>
+            <div class="services-pattern services-pattern--dark absolute inset-0 -z-10"></div>
             <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
                 <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-white/70 backdrop-blur-sm text-emerald-700">
                     <ChartBar class="w-6 h-6" stroke-width="1.5" />
@@ -78,49 +78,29 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
 
     .services-mesh--primary {
         background-color: #064e3b;
-        background-image:
-            radial-gradient(ellipse 70% 60% at 90% 100%, hsla(160, 70%, 45%, 0.32) 0%, transparent 70%),
-            radial-gradient(ellipse 60% 60% at 10% 0%, hsla(170, 60%, 30%, 0.4) 0%, transparent 75%);
+        background-image: radial-gradient(ellipse 80% 70% at 100% 100%, hsla(160, 65%, 45%, 0.18) 0%, transparent 75%);
     }
 
     .services-mesh--mint {
         background-color: #f0fdf4;
-        background-image:
-            radial-gradient(ellipse 70% 60% at 95% 5%, hsla(160, 75%, 80%, 0.45) 0%, transparent 70%),
-            radial-gradient(ellipse 60% 60% at 5% 95%, hsla(155, 60%, 88%, 0.5) 0%, transparent 75%);
+        background-image: radial-gradient(ellipse 80% 70% at 100% 0%, hsla(160, 65%, 82%, 0.28) 0%, transparent 75%);
     }
 
     .services-mesh--sand {
         background-color: #fafafa;
-        background-image:
-            radial-gradient(ellipse 65% 60% at 5% 0%, hsla(160, 60%, 92%, 0.6) 0%, transparent 75%),
-            radial-gradient(ellipse 70% 60% at 95% 100%, hsla(200, 55%, 92%, 0.45) 0%, transparent 75%);
+        background-image: radial-gradient(ellipse 80% 70% at 0% 100%, hsla(160, 55%, 90%, 0.35) 0%, transparent 75%);
     }
 
     .services-pattern {
         pointer-events: none;
-        -webkit-mask-image: radial-gradient(ellipse 75% 80% at 100% 100%, black 0%, transparent 70%);
-        mask-image: radial-gradient(ellipse 75% 80% at 100% 100%, black 0%, transparent 70%);
+        background-size: 20px 20px;
     }
 
-    .services-pattern--stripes {
-        background-image: repeating-linear-gradient(
-            45deg,
-            rgba(255, 255, 255, 0.09) 0,
-            rgba(255, 255, 255, 0.09) 1px,
-            transparent 1px,
-            transparent 12px
-        );
+    .services-pattern--light {
+        background-image: radial-gradient(circle, rgba(255, 255, 255, 0.1) 1px, transparent 1.2px);
     }
 
-    .services-pattern--waves {
-        background-image: url("data:image/svg+xml;utf8,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 200 40' preserveAspectRatio='none'%3E%3Cpath d='M0 20 Q 50 0 100 20 T 200 20' fill='none' stroke='%23047857' stroke-width='1.2' opacity='0.22'/%3E%3C/svg%3E");
-        background-size: 180px 36px;
-        background-repeat: repeat;
-    }
-
-    .services-pattern--dots {
-        background-image: radial-gradient(circle, rgba(4, 120, 87, 0.22) 1.4px, transparent 1.6px);
-        background-size: 18px 18px;
+    .services-pattern--dark {
+        background-image: radial-gradient(circle, rgba(4, 120, 87, 0.14) 1px, transparent 1.2px);
     }
 </style>

--- a/src/features/home/components/services.astro
+++ b/src/features/home/components/services.astro
@@ -1,6 +1,87 @@
 ---
 import "@app/styles/global.css";
-import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
+import { CodeXml, Zap, ChartBar, ArrowRight, Maximize2, X } from "@lucide/astro";
+
+const serviceModals = [
+    {
+        id: "software",
+        icon: CodeXml,
+        title: "Software a medida",
+        intro: "Construimos aplicaciones diseñadas para los procesos únicos de tu empresa: herramientas internas, paneles de control, integraciones entre sistemas y plataformas que crecen contigo, sin atarte a soluciones genéricas.",
+        sections: [
+            {
+                title: "Qué construimos",
+                items: [
+                    "Aplicaciones web internas y dashboards a la medida",
+                    "Integraciones entre ERPs, CRMs y APIs externas",
+                    "Portales para clientes, proveedores o tu equipo interno",
+                    "Modernización de software legacy",
+                ],
+            },
+            {
+                title: "Cómo trabajamos",
+                items: [
+                    "Descubrimiento profundo de tus procesos reales",
+                    "Prototipado y validación con quienes lo usarán",
+                    "Entregas iterativas, sin sorpresas al final",
+                    "Despliegue, capacitación y acompañamiento continuo",
+                ],
+            },
+        ],
+    },
+    {
+        id: "automation",
+        icon: Zap,
+        title: "Automatización",
+        intro: "Eliminamos el trabajo repetitivo conectando tus sistemas y automatizando los flujos que hoy consumen horas de tu equipo. Menos errores, más velocidad, y personas enfocadas en lo que realmente importa.",
+        sections: [
+            {
+                title: "Qué automatizamos",
+                items: [
+                    "Flujos entre herramientas (ERP, CRM, hojas de cálculo, email)",
+                    "Generación y envío de reportes recurrentes",
+                    "Procesos de onboarding, facturación y notificaciones",
+                    "Sincronización de datos entre sistemas",
+                ],
+            },
+            {
+                title: "Cómo trabajamos",
+                items: [
+                    "Mapeamos los procesos donde se está perdiendo tiempo",
+                    "Diseñamos el flujo automatizado y lo validamos contigo",
+                    "Implementamos con herramientas robustas y scripts a medida",
+                    "Monitoreamos y ajustamos según evoluciona el proceso",
+                ],
+            },
+        ],
+    },
+    {
+        id: "consulting",
+        icon: ChartBar,
+        title: "Consultoría estratégica",
+        intro: "Analizamos tu operación tecnológica y construimos un roadmap claro para priorizar lo que mueve la aguja de tu negocio. Decisiones basadas en datos, no en intuiciones.",
+        sections: [
+            {
+                title: "Qué entregamos",
+                items: [
+                    "Diagnóstico técnico y de procesos",
+                    "Roadmap priorizado por impacto y esfuerzo",
+                    "Recomendaciones de arquitectura y stack",
+                    "Evaluación de proveedores y herramientas",
+                ],
+            },
+            {
+                title: "Cómo trabajamos",
+                items: [
+                    "Sesiones de descubrimiento con tu equipo y stakeholders",
+                    "Análisis de tu stack actual y sus cuellos de botella",
+                    "Talleres para priorizar iniciativas",
+                    "Entregables ejecutables, no documentos genéricos",
+                ],
+            },
+        ],
+    },
+];
 ---
 
 <section id="services" class="container mx-auto py-20 md:py-24 lg:py-28">
@@ -24,6 +105,14 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
         <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[20rem] md:min-h-[22rem] text-emerald-50 transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
             <div class="services-mesh services-mesh--primary absolute inset-0 -z-10"></div>
             <div class="services-pattern services-pattern--light absolute inset-0 -z-10"></div>
+            <button
+                type="button"
+                data-service-trigger="software"
+                aria-label="Ver más sobre Software a medida"
+                class="services-expand services-expand--light absolute top-6 right-6 md:top-8 md:right-8 z-20"
+            >
+                <Maximize2 class="w-4 h-4" stroke-width={2} />
+            </button>
             <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
                 <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-white/15 backdrop-blur-sm">
                     <CodeXml class="w-6 h-6 text-white" stroke-width="1.5" />
@@ -40,6 +129,14 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
         <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[20rem] md:min-h-[22rem] transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
             <div class="services-mesh services-mesh--mint absolute inset-0 -z-10"></div>
             <div class="services-pattern services-pattern--dark absolute inset-0 -z-10"></div>
+            <button
+                type="button"
+                data-service-trigger="automation"
+                aria-label="Ver más sobre Automatización"
+                class="services-expand services-expand--dark absolute top-6 right-6 md:top-8 md:right-8 z-20"
+            >
+                <Maximize2 class="w-4 h-4" stroke-width={2} />
+            </button>
             <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
                 <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-white/70 backdrop-blur-sm text-emerald-700">
                     <Zap class="w-6 h-6" stroke-width="1.5" />
@@ -56,6 +153,14 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
         <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[20rem] md:min-h-[22rem] transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
             <div class="services-mesh services-mesh--sand absolute inset-0 -z-10"></div>
             <div class="services-pattern services-pattern--dark absolute inset-0 -z-10"></div>
+            <button
+                type="button"
+                data-service-trigger="consulting"
+                aria-label="Ver más sobre Consultoría estratégica"
+                class="services-expand services-expand--dark absolute top-6 right-6 md:top-8 md:right-8 z-20"
+            >
+                <Maximize2 class="w-4 h-4" stroke-width={2} />
+            </button>
             <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
                 <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-white/70 backdrop-blur-sm text-emerald-700">
                     <ChartBar class="w-6 h-6" stroke-width="1.5" />
@@ -70,6 +175,69 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
         </article>
     </div>
 </section>
+
+{
+    serviceModals.map((modal) => {
+        const Icon = modal.icon;
+        return (
+            <dialog
+                data-service-modal={modal.id}
+                aria-labelledby={`services-modal-${modal.id}-title`}
+                class="services-modal"
+            >
+                <div data-service-panel class="services-panel">
+                    <button
+                        type="button"
+                        data-service-close
+                        aria-label="Cerrar"
+                        class="services-close absolute top-5 right-5 md:top-6 md:right-6 z-10 w-10 h-10 flex items-center justify-center rounded-full text-zinc-500 hover:text-zinc-900 hover:bg-zinc-100 transition-colors"
+                    >
+                        <X class="w-5 h-5" stroke-width={2} />
+                    </button>
+                    <div class="flex flex-col gap-6 md:gap-8 p-8 pt-16 md:p-12 md:pt-16">
+                        <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-emerald-50 text-emerald-700">
+                            <Icon class="w-6 h-6" stroke-width={1.5} />
+                        </div>
+                        <h3
+                            id={`services-modal-${modal.id}-title`}
+                            class="text-3xl md:text-4xl font-semibold leading-tight text-zinc-900"
+                        >
+                            {modal.title}
+                        </h3>
+                        <p class="text-zinc-600 text-base md:text-lg leading-relaxed">
+                            {modal.intro}
+                        </p>
+                        {modal.sections.map((section) => (
+                            <div class="flex flex-col gap-3">
+                                <h4 class="text-xs font-semibold uppercase tracking-wider text-emerald-700">
+                                    {section.title}
+                                </h4>
+                                <ul class="flex flex-col gap-2.5">
+                                    {section.items.map((item) => (
+                                        <li class="flex gap-3 text-zinc-700 text-sm md:text-base leading-relaxed">
+                                            <span class="mt-2 shrink-0 w-1.5 h-1.5 rounded-full bg-emerald-600" />
+                                            <span>{item}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        ))}
+                        <a
+                            href="/contact"
+                            class="group inline-flex items-center gap-2 mt-2 text-emerald-700 font-semibold text-sm md:text-base transition-colors hover:text-emerald-900"
+                        >
+                            Solicitar consultoría
+                            <ArrowRight
+                                class="w-4 h-4 transition-transform group-hover:translate-x-1"
+                                stroke-width={2}
+                            />
+                        </a>
+                    </div>
+                </div>
+            </dialog>
+        );
+    })
+}
 
 <style>
     .services-mesh {
@@ -103,4 +271,153 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
     .services-pattern--dark {
         background-image: radial-gradient(circle, rgba(4, 120, 87, 0.14) 1px, transparent 1.2px);
     }
+
+    .services-expand {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 2.25rem;
+        height: 2.25rem;
+        border-radius: 0.75rem;
+        backdrop-filter: blur(8px);
+        -webkit-backdrop-filter: blur(8px);
+        cursor: pointer;
+        transition: background-color 200ms ease, transform 200ms ease;
+    }
+
+    .services-expand:hover {
+        transform: scale(1.05);
+    }
+
+    .services-expand--light {
+        background-color: rgba(255, 255, 255, 0.15);
+        color: rgba(255, 255, 255, 0.95);
+    }
+
+    .services-expand--light:hover {
+        background-color: rgba(255, 255, 255, 0.25);
+    }
+
+    .services-expand--dark {
+        background-color: rgba(255, 255, 255, 0.75);
+        color: #047857;
+    }
+
+    .services-expand--dark:hover {
+        background-color: rgba(255, 255, 255, 1);
+    }
+
+    dialog.services-modal {
+        width: 100%;
+        max-width: none;
+        height: 100%;
+        max-height: none;
+        border: none;
+        padding: 0;
+        margin: 0;
+        background: transparent;
+        overflow: hidden;
+    }
+
+    dialog.services-modal::backdrop {
+        background-color: rgba(24, 24, 27, 0.5);
+        -webkit-backdrop-filter: blur(4px);
+        backdrop-filter: blur(4px);
+        opacity: 0;
+        transition: opacity 300ms ease;
+    }
+
+    dialog.services-modal[open]::backdrop {
+        opacity: 1;
+    }
+
+    .services-panel {
+        position: absolute;
+        top: 0;
+        right: 0;
+        height: 100%;
+        width: 100%;
+        max-width: 36rem;
+        background-color: #ffffff;
+        box-shadow: -20px 0 60px -20px rgba(0, 0, 0, 0.25);
+        overflow-y: auto;
+        transform: translateX(100%);
+        transition: transform 320ms cubic-bezier(0.22, 1, 0.36, 1);
+        will-change: transform;
+    }
+
+    dialog.services-modal[data-open] .services-panel {
+        transform: translateX(0);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .services-panel,
+        dialog.services-modal::backdrop {
+            transition: none;
+        }
+    }
 </style>
+
+<script>
+    const dialogs = document.querySelectorAll<HTMLDialogElement>(
+        "dialog[data-service-modal]"
+    );
+    const triggers = document.querySelectorAll<HTMLButtonElement>(
+        "[data-service-trigger]"
+    );
+
+    function getDialog(id: string): HTMLDialogElement | null {
+        return document.querySelector<HTMLDialogElement>(
+            `dialog[data-service-modal="${id}"]`
+        );
+    }
+
+    function openDialog(dialog: HTMLDialogElement) {
+        dialog.showModal();
+        document.body.style.overflow = "hidden";
+        requestAnimationFrame(() => {
+            dialog.setAttribute("data-open", "");
+        });
+    }
+
+    function closeDialog(dialog: HTMLDialogElement) {
+        const panel = dialog.querySelector<HTMLElement>("[data-service-panel]");
+        dialog.removeAttribute("data-open");
+        const finish = () => {
+            dialog.close();
+            document.body.style.overflow = "";
+            panel?.removeEventListener("transitionend", finish);
+        };
+        if (panel) {
+            panel.addEventListener("transitionend", finish, { once: true });
+        } else {
+            finish();
+        }
+    }
+
+    triggers.forEach((trigger) => {
+        trigger.addEventListener("click", () => {
+            const id = trigger.dataset.serviceTrigger;
+            if (!id) return;
+            const dialog = getDialog(id);
+            if (dialog) openDialog(dialog);
+        });
+    });
+
+    dialogs.forEach((dialog) => {
+        dialog.addEventListener("click", (event) => {
+            if (event.target === dialog) closeDialog(dialog);
+        });
+
+        dialog.addEventListener("cancel", (event) => {
+            event.preventDefault();
+            closeDialog(dialog);
+        });
+
+        dialog
+            .querySelectorAll<HTMLButtonElement>("[data-service-close]")
+            .forEach((btn) => {
+                btn.addEventListener("click", () => closeDialog(dialog));
+            });
+    });
+</script>

--- a/src/features/home/components/services.astro
+++ b/src/features/home/components/services.astro
@@ -21,9 +21,9 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
     </div>
 
     <div class="flex flex-col gap-6 md:gap-8">
-        <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[26rem] md:min-h-[30rem] text-emerald-50 transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
+        <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[20rem] md:min-h-[22rem] text-emerald-50 transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
             <div class="services-mesh services-mesh--primary absolute inset-0 -z-10"></div>
-            <CodeXml class="absolute right-6 md:right-10 bottom-6 md:bottom-10 w-48 h-48 md:w-64 md:h-64 text-white/10 -z-10" stroke-width={1} />
+            <CodeXml class="absolute right-8 md:right-12 bottom-8 md:bottom-12 w-40 h-40 md:w-52 md:h-52 text-white/[0.07] -z-10" stroke-width={1} />
             <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
                 <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-white/15 backdrop-blur-sm">
                     <CodeXml class="w-6 h-6 text-white" stroke-width="1.5" />
@@ -37,9 +37,9 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
             </div>
         </article>
 
-        <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[26rem] md:min-h-[30rem] transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
+        <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[20rem] md:min-h-[22rem] transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
             <div class="services-mesh services-mesh--mint absolute inset-0 -z-10"></div>
-            <Zap class="absolute right-6 md:right-10 bottom-6 md:bottom-10 w-48 h-48 md:w-64 md:h-64 text-emerald-800/10 -z-10" stroke-width={1} />
+            <Zap class="absolute right-8 md:right-12 bottom-8 md:bottom-12 w-40 h-40 md:w-52 md:h-52 text-emerald-900/[0.06] -z-10" stroke-width={1} />
             <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
                 <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-white/70 backdrop-blur-sm text-emerald-700">
                     <Zap class="w-6 h-6" stroke-width="1.5" />
@@ -53,9 +53,9 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
             </div>
         </article>
 
-        <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[26rem] md:min-h-[30rem] transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
+        <article class="services-card relative isolate overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[20rem] md:min-h-[22rem] transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
             <div class="services-mesh services-mesh--sand absolute inset-0 -z-10"></div>
-            <ChartBar class="absolute right-6 md:right-10 bottom-6 md:bottom-10 w-48 h-48 md:w-64 md:h-64 text-emerald-800/10 -z-10" stroke-width={1} />
+            <ChartBar class="absolute right-8 md:right-12 bottom-8 md:bottom-12 w-40 h-40 md:w-52 md:h-52 text-emerald-900/[0.06] -z-10" stroke-width={1} />
             <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
                 <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-white/70 backdrop-blur-sm text-emerald-700">
                     <ChartBar class="w-6 h-6" stroke-width="1.5" />
@@ -77,35 +77,23 @@ import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
     }
 
     .services-mesh--primary {
-        background-color: #022c22;
+        background-color: #064e3b;
         background-image:
-            radial-gradient(at 18% 22%, hsla(160, 84%, 45%, 0.65) 0px, transparent 55%),
-            radial-gradient(at 88% 12%, hsla(178, 78%, 42%, 0.55) 0px, transparent 55%),
-            radial-gradient(at 72% 88%, hsla(94, 70%, 55%, 0.45) 0px, transparent 55%),
-            radial-gradient(at 12% 78%, hsla(165, 96%, 24%, 0.85) 0px, transparent 60%),
-            radial-gradient(at 96% 52%, hsla(150, 80%, 38%, 0.55) 0px, transparent 55%),
-            radial-gradient(at 40% 50%, hsla(175, 80%, 32%, 0.45) 0px, transparent 55%);
+            radial-gradient(ellipse 70% 60% at 90% 100%, hsla(160, 70%, 45%, 0.32) 0%, transparent 70%),
+            radial-gradient(ellipse 60% 60% at 10% 0%, hsla(170, 60%, 30%, 0.4) 0%, transparent 75%);
     }
 
     .services-mesh--mint {
         background-color: #f0fdf4;
         background-image:
-            radial-gradient(at 16% 24%, hsla(160, 90%, 76%, 0.7) 0px, transparent 55%),
-            radial-gradient(at 90% 12%, hsla(178, 82%, 80%, 0.65) 0px, transparent 55%),
-            radial-gradient(at 78% 92%, hsla(95, 86%, 78%, 0.6) 0px, transparent 55%),
-            radial-gradient(at 8% 82%, hsla(168, 80%, 78%, 0.6) 0px, transparent 55%),
-            radial-gradient(at 96% 58%, hsla(35, 92%, 86%, 0.55) 0px, transparent 55%),
-            radial-gradient(at 42% 48%, hsla(160, 100%, 92%, 0.7) 0px, transparent 55%);
+            radial-gradient(ellipse 70% 60% at 95% 5%, hsla(160, 75%, 80%, 0.45) 0%, transparent 70%),
+            radial-gradient(ellipse 60% 60% at 5% 95%, hsla(155, 60%, 88%, 0.5) 0%, transparent 75%);
     }
 
     .services-mesh--sand {
         background-color: #fafafa;
         background-image:
-            radial-gradient(at 82% 8%, hsla(160, 70%, 86%, 0.7) 0px, transparent 55%),
-            radial-gradient(at 6% 42%, hsla(200, 75%, 88%, 0.6) 0px, transparent 55%),
-            radial-gradient(at 82% 96%, hsla(150, 88%, 84%, 0.65) 0px, transparent 55%),
-            radial-gradient(at 4% 6%, hsla(35, 76%, 92%, 0.55) 0px, transparent 55%),
-            radial-gradient(at 96% 52%, hsla(175, 82%, 90%, 0.6) 0px, transparent 55%),
-            radial-gradient(at 48% 60%, hsla(155, 70%, 94%, 0.7) 0px, transparent 55%);
+            radial-gradient(ellipse 65% 60% at 5% 0%, hsla(160, 60%, 92%, 0.6) 0%, transparent 75%),
+            radial-gradient(ellipse 70% 60% at 95% 100%, hsla(200, 55%, 92%, 0.45) 0%, transparent 75%);
     }
 </style>

--- a/src/features/home/components/services.astro
+++ b/src/features/home/components/services.astro
@@ -1,76 +1,93 @@
 ---
 import "@app/styles/global.css";
-import { CodeXml, Globe, Zap, ChartBar, Wrench, ArrowRight } from "@lucide/astro";
+import { CodeXml, Zap, ChartBar, ArrowRight } from "@lucide/astro";
 ---
 
 <section id="services" class="container mx-auto py-20 md:py-24 lg:py-28">
-    <div class="flex flex-wrap gap-6 md:gap-8">
-        <div class="w-full md:w-[calc(50%-1rem)] lg:w-[calc(33.333%-1.333rem)] flex flex-col gap-4 md:gap-6 md:justify-between">
-            <div class="flex flex-col gap-4">
-                <h2 class="text-2xl sm:text-3xl md:text-4xl font-semibold leading-tight text-zinc-800">
-                    Soluciones
-                </h2>
-                <p class="text-zinc-600 text-sm md:text-base leading-relaxed">
-                    Transformamos la operación de tu empresa con tecnología que funciona.
+    <div class="flex flex-col gap-4 max-w-2xl mb-12 md:mb-16">
+        <h2 class="text-2xl sm:text-3xl md:text-4xl font-semibold leading-tight text-zinc-800">
+            Soluciones
+        </h2>
+        <p class="text-zinc-600 text-sm md:text-base leading-relaxed">
+            Transformamos la operación de tu empresa con tecnología que funciona.
+        </p>
+        <a
+            href="/contact"
+            class="group inline-flex items-center gap-2 text-emerald-700 font-semibold text-sm md:text-base transition-colors hover:text-emerald-900"
+        >
+            Solicitar consultoría
+            <ArrowRight class="w-4 h-4 transition-transform group-hover:translate-x-1" stroke-width={2} />
+        </a>
+    </div>
+
+    <div class="flex flex-col gap-6 md:gap-8">
+        <article class="services-card services-card--primary relative overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[26rem] md:min-h-[30rem] bg-emerald-700 text-emerald-100 transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
+            <div class="services-dots services-dots--light absolute inset-0"></div>
+            <div class="absolute -bottom-24 -right-16 w-[28rem] h-[28rem] rounded-full bg-emerald-300/30 blur-3xl"></div>
+            <CodeXml class="absolute right-6 md:right-10 bottom-6 md:bottom-10 w-48 h-48 md:w-64 md:h-64 text-emerald-100/10" stroke-width={1} />
+            <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
+                <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-emerald-100/15">
+                    <CodeXml class="w-6 h-6 text-emerald-100" stroke-width="1.5" />
+                </div>
+                <h3 class="text-2xl md:text-3xl lg:text-4xl font-semibold leading-tight">
+                    Software a medida
+                </h3>
+                <p class="text-emerald-100/80 text-base md:text-lg leading-relaxed">
+                    Soluciones personalizadas que se adaptan a los procesos únicos de tu negocio.
                 </p>
-                <a
-                    href="/contact"
-                    class="group inline-flex items-center gap-2 text-emerald-700 font-semibold text-sm md:text-base transition-colors hover:text-emerald-900"
-                >
-                    Solicitar consultoría
-                    <ArrowRight class="w-4 h-4 transition-transform group-hover:translate-x-1" stroke-width={2} />
-                </a>
             </div>
-        </div>
-
-        <article class="w-full md:w-[calc(50%-1rem)] lg:w-[calc(33.333%-1.333rem)] flex flex-col gap-4 rounded-2xl p-6 md:p-8 bg-emerald-700 text-emerald-100 transition-all duration-300 ease-in-out hover:scale-[101%] hover:translate-y-[-.5rem]">
-            <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-emerald-100/15">
-                <CodeXml class="w-6 h-6 text-emerald-100" stroke-width="1.5" />
-            </div>
-            <h3 class="text-lg md:text-xl font-semibold">Software a medida</h3>
-            <p class="text-emerald-100/80 text-sm md:text-base leading-relaxed">
-                Soluciones personalizadas que se adaptan a los procesos únicos de tu negocio.
-            </p>
         </article>
 
-        <article class="w-full md:w-[calc(50%-1rem)] lg:w-[calc(33.333%-1.333rem)] flex flex-col gap-4 bg-emerald-50/70 rounded-2xl p-6 md:p-8 transition-all duration-300 ease-in-out hover:scale-[101%] hover:translate-y-[-.5rem]">
-            <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-emerald-100 text-emerald-700">
-                <Globe class="w-6 h-6" stroke-width="1.5" />
+        <article class="services-card relative overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[26rem] md:min-h-[30rem] bg-emerald-50/70 transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
+            <div class="services-dots services-dots--dark absolute inset-0"></div>
+            <div class="absolute -top-20 -right-20 w-[24rem] h-[24rem] rounded-full bg-emerald-300/40 blur-3xl"></div>
+            <Zap class="absolute right-6 md:right-10 bottom-6 md:bottom-10 w-48 h-48 md:w-64 md:h-64 text-emerald-700/10" stroke-width={1} />
+            <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
+                <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-emerald-100 text-emerald-700">
+                    <Zap class="w-6 h-6" stroke-width="1.5" />
+                </div>
+                <h3 class="text-2xl md:text-3xl lg:text-4xl font-semibold leading-tight text-zinc-800">
+                    Automatización
+                </h3>
+                <p class="text-zinc-600 text-base md:text-lg leading-relaxed">
+                    Flujos automatizados que eliminan trabajo repetitivo y reducen errores.
+                </p>
             </div>
-            <h3 class="text-lg md:text-xl font-semibold text-zinc-800">Plataformas web</h3>
-            <p class="text-zinc-600 text-sm md:text-base leading-relaxed">
-                Aplicaciones web robustas y escalables para centralizar la operación de tu empresa.
-            </p>
         </article>
 
-        <article class="w-full md:w-[calc(50%-1rem)] lg:w-[calc(33.333%-1.333rem)] flex flex-col gap-4 bg-emerald-50/70 rounded-2xl p-6 md:p-8 transition-all duration-300 ease-in-out hover:scale-[101%] hover:translate-y-[-.5rem]">
-            <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-emerald-100 text-emerald-700">
-                <Zap class="w-6 h-6" stroke-width="1.5" />
+        <article class="services-card relative overflow-hidden rounded-3xl p-8 md:p-12 lg:p-16 min-h-[26rem] md:min-h-[30rem] bg-zinc-50 transition-transform duration-300 ease-in-out hover:translate-y-[-.5rem]">
+            <div class="services-dots services-dots--dark absolute inset-0"></div>
+            <div class="absolute -bottom-24 -left-16 w-[26rem] h-[26rem] rounded-full bg-emerald-200/50 blur-3xl"></div>
+            <ChartBar class="absolute right-6 md:right-10 bottom-6 md:bottom-10 w-48 h-48 md:w-64 md:h-64 text-emerald-700/10" stroke-width={1} />
+            <div class="relative z-10 max-w-xl flex flex-col gap-4 md:gap-5">
+                <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-emerald-100 text-emerald-700">
+                    <ChartBar class="w-6 h-6" stroke-width="1.5" />
+                </div>
+                <h3 class="text-2xl md:text-3xl lg:text-4xl font-semibold leading-tight text-zinc-800">
+                    Consultoría estratégica
+                </h3>
+                <p class="text-zinc-600 text-base md:text-lg leading-relaxed">
+                    Análisis y roadmap técnico para priorizar lo que mueve la aguja de tu negocio.
+                </p>
             </div>
-            <h3 class="text-lg md:text-xl font-semibold text-zinc-800">Automatización</h3>
-            <p class="text-zinc-600 text-sm md:text-base leading-relaxed">
-                Flujos automatizados que eliminan trabajo repetitivo y reducen errores.
-            </p>
-        </article>
-
-        <article class="w-full md:w-[calc(50%-1rem)] lg:w-[calc(33.333%-1.333rem)] flex flex-col gap-4 bg-emerald-50/70 rounded-2xl p-6 md:p-8 transition-all duration-300 ease-in-out hover:scale-[101%] hover:translate-y-[-.5rem]">
-            <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-emerald-100 text-emerald-700">
-                <ChartBar class="w-6 h-6" stroke-width="1.5" />
-            </div>
-            <h3 class="text-lg md:text-xl font-semibold text-zinc-800">Consultoría estratégica</h3>
-            <p class="text-zinc-600 text-sm md:text-base leading-relaxed">
-                Análisis y roadmap técnico para priorizar lo que mueve la aguja de tu negocio.
-            </p>
-        </article>
-
-        <article class="w-full md:w-[calc(50%-1rem)] lg:w-[calc(33.333%-1.333rem)] flex flex-col gap-4 bg-emerald-50/70 rounded-2xl p-6 md:p-8 transition-all duration-300 ease-in-out hover:scale-[101%] hover:translate-y-[-.5rem]">
-            <div class="w-12 h-12 flex items-center justify-center rounded-xl bg-emerald-100 text-emerald-700">
-                <Wrench class="w-6 h-6" stroke-width="1.5" />
-            </div>
-            <h3 class="text-lg md:text-xl font-semibold text-zinc-800">Mantenimiento y soporte</h3>
-            <p class="text-zinc-600 text-sm md:text-base leading-relaxed">
-                Evolución continua de tus productos para que nunca se queden atrás.
-            </p>
         </article>
     </div>
 </section>
+
+<style>
+    .services-dots {
+        background-image: radial-gradient(circle, currentColor 1px, transparent 1px);
+        background-size: 22px 22px;
+        -webkit-mask-image: radial-gradient(ellipse 70% 70% at 80% 80%, black 0%, transparent 70%);
+        mask-image: radial-gradient(ellipse 70% 70% at 80% 80%, black 0%, transparent 70%);
+        pointer-events: none;
+    }
+
+    .services-dots--light {
+        color: rgba(209, 250, 229, 0.18);
+    }
+
+    .services-dots--dark {
+        color: rgba(4, 120, 87, 0.12);
+    }
+</style>


### PR DESCRIPTION
## Summary

- Reduce the homepage `Soluciones` section from 5 dense grid cards to 3 focused, full-width stacked canvases so visitors aren't overwhelmed.
- Drop `Plataformas web` (overlaps with `Software a medida`) and `Mantenimiento y soporte` (ongoing add-on).
- Each card uses a single shared dot pattern (light dots on the primary, emerald dots on the light cards), spanning the full card like a page-style background, paired with a very subtle corner gradient wash.
- Aligns with the site's minimal aesthetic: one decoration system, quiet color, headline-led composition.

## Test plan

- [ ] Visit homepage, scroll to `#services` (also reachable via navbar and footer "Soluciones" links).
- [ ] Verify intro block on top, then three stacked cards: Software a medida (deep emerald, light dots), Automatización (mint, emerald dots), Consultoría estratégica (neutral, emerald dots).
- [ ] Confirm gradient and dot pattern are visibly subtle — heading and copy lead.
- [ ] Confirm dot pattern stays inside the rounded corners on every card.
- [ ] Hover each card → subtle lift, no scale jump.
- [ ] Check breakpoints: mobile stacks tall, `md` and `lg` keep the same vertical stack with larger padding.
- [ ] Click "Solicitar consultoría" → routes to `/contact`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TsAb8Y3nXdGuGzw1teyuUh)_