### PR TITLE
feat(hero): auto-loop dotted spotlight as breathing pulse on viewport visibility

### DIFF
--- a/src/features/home/components/hero.astro
+++ b/src/features/home/components/hero.astro
@@ -72,8 +72,8 @@ import Button from "@shared/components/ui/button.astro";
     .hero-dots-active {
         background-image: radial-gradient(
             circle,
-            rgba(4, 120, 87, 0.6) 1px,
-            transparent 1.3px
+            rgba(4, 120, 87, 0.95) 1.2px,
+            transparent 1.6px
         );
         background-size: 13px 13px;
         mask-image: radial-gradient(
@@ -130,8 +130,8 @@ import Button from "@shared/components/ui/button.astro";
         .hero-dots-active {
             background-image: radial-gradient(
                 circle,
-                rgba(4, 120, 87, 0.6) 1.3px,
-                transparent 1.7px
+                rgba(4, 120, 87, 0.95) 1.6px,
+                transparent 2px
             );
             background-size: 18px 18px;
         }

--- a/src/features/home/components/hero.astro
+++ b/src/features/home/components/hero.astro
@@ -72,8 +72,8 @@ import Button from "@shared/components/ui/button.astro";
     .hero-dots-active {
         background-image: radial-gradient(
             circle,
-            rgba(4, 120, 87, 0.95) 1.2px,
-            transparent 1.6px
+            rgba(4, 120, 87, 0.6) 1px,
+            transparent 1.3px
         );
         background-size: 13px 13px;
         mask-image: radial-gradient(
@@ -130,8 +130,8 @@ import Button from "@shared/components/ui/button.astro";
         .hero-dots-active {
             background-image: radial-gradient(
                 circle,
-                rgba(4, 120, 87, 0.95) 1.6px,
-                transparent 2px
+                rgba(4, 120, 87, 0.6) 1.3px,
+                transparent 1.7px
             );
             background-size: 18px 18px;
         }
@@ -183,15 +183,14 @@ import Button from "@shared/components/ui/button.astro";
         const startLoop = () => {
             if (loopControls || pointerActive || prefersReducedMotion) return;
             card.style.setProperty("--hero-mouse-x", "50%");
-            card.style.setProperty("--hero-mouse-y", "50%");
             loopControls = animate(
                 card,
-                { "--hero-mask-radius": ["180px", "420px"] },
+                { "--hero-mouse-y": ["-15%", "115%"] },
                 {
-                    duration: 3.6,
-                    ease: [0.45, 0, 0.55, 1],
+                    duration: 5,
+                    ease: "linear",
                     repeat: Infinity,
-                    repeatType: "mirror",
+                    repeatType: "loop",
                 }
             );
         };
@@ -232,22 +231,25 @@ import Button from "@shared/components/ui/button.astro";
                 rect = null;
                 pendingX = "100%";
                 pendingY = "100%";
-                if (!rafId) rafId = requestAnimationFrame(apply);
-                if (inViewport) startLoop();
-            };
-
-            const pinRadius = () => {
-                if (pointerActive) {
-                    card.style.setProperty("--hero-mask-radius", "260px");
+                if (rafId) {
+                    cancelAnimationFrame(rafId);
+                    rafId = 0;
+                }
+                if (inViewport) {
+                    startLoop();
+                } else {
+                    rafId = requestAnimationFrame(apply);
                 }
             };
 
-            card.addEventListener("pointerenter", () => {
+            card.addEventListener("pointerenter", (e) => {
                 pointerActive = true;
                 stopLoop();
-                pinRadius();
-                requestAnimationFrame(pinRadius);
                 rect = card.getBoundingClientRect();
+                pendingX = `${((e.clientX - rect.left) / rect.width) * 100}%`;
+                pendingY = `${((e.clientY - rect.top) / rect.height) * 100}%`;
+                apply();
+                rafId = requestAnimationFrame(apply);
             });
 
             card.addEventListener("pointermove", (e) => {

--- a/src/features/home/components/hero.astro
+++ b/src/features/home/components/hero.astro
@@ -187,7 +187,7 @@ import Button from "@shared/components/ui/button.astro";
                 card,
                 { "--hero-mouse-y": ["-15%", "115%"] },
                 {
-                    duration: 5,
+                    duration: 2.4,
                     ease: "linear",
                     repeat: Infinity,
                     repeatType: "loop",

--- a/src/features/home/components/hero.astro
+++ b/src/features/home/components/hero.astro
@@ -77,14 +77,14 @@ import Button from "@shared/components/ui/button.astro";
         );
         background-size: 13px 13px;
         mask-image: radial-gradient(
-            circle 260px at var(--hero-mouse-x, 100%) var(--hero-mouse-y, 100%),
+            circle var(--hero-mask-radius, 260px) at var(--hero-mouse-x, 100%) var(--hero-mouse-y, 100%),
             #000 0%,
             rgba(0, 0, 0, 0.55) 35%,
             rgba(0, 0, 0, 0.2) 80%,
             transparent 100%
         );
         -webkit-mask-image: radial-gradient(
-            circle 260px at var(--hero-mouse-x, 100%) var(--hero-mouse-y, 100%),
+            circle var(--hero-mask-radius, 260px) at var(--hero-mouse-x, 100%) var(--hero-mouse-y, 100%),
             #000 0%,
             rgba(0, 0, 0, 0.55) 35%,
             rgba(0, 0, 0, 0.2) 80%,
@@ -110,6 +110,10 @@ import Button from "@shared/components/ui/button.astro";
             animation: none !important;
             opacity: 1 !important;
             transform: none !important;
+        }
+
+        .hero-dots-active {
+            --hero-mask-radius: 260px;
         }
     }
 
@@ -161,41 +165,102 @@ import Button from "@shared/components/ui/button.astro";
 </style>
 
 <script>
+    import { animate, inView } from "framer-motion";
+
     const card = document.querySelector<HTMLElement>("[data-hero-card]");
     const supportsFinePointer = window.matchMedia(
         "(hover: hover) and (pointer: fine)"
     ).matches;
+    const prefersReducedMotion = window.matchMedia(
+        "(prefers-reduced-motion: reduce)"
+    ).matches;
 
-    if (card && supportsFinePointer) {
-        let rafId = 0;
-        let pendingX = "100%";
-        let pendingY = "100%";
-        let rect: DOMRect | null = null;
+    if (card) {
+        let loopControls: ReturnType<typeof animate> | null = null;
+        let pointerActive = false;
+        let inViewport = false;
 
-        const apply = () => {
-            rafId = 0;
-            card.style.setProperty("--hero-mouse-x", pendingX);
-            card.style.setProperty("--hero-mouse-y", pendingY);
+        const startLoop = () => {
+            if (loopControls || pointerActive || prefersReducedMotion) return;
+            card.style.setProperty("--hero-mouse-x", "50%");
+            card.style.setProperty("--hero-mouse-y", "50%");
+            loopControls = animate(
+                card,
+                { "--hero-mask-radius": ["180px", "420px"] },
+                {
+                    duration: 3.6,
+                    ease: [0.45, 0, 0.55, 1],
+                    repeat: Infinity,
+                    repeatType: "mirror",
+                }
+            );
         };
 
-        card.addEventListener("pointerenter", () => {
-            rect = card.getBoundingClientRect();
-        });
+        const stopLoop = () => {
+            if (!loopControls) return;
+            loopControls.stop();
+            loopControls = null;
+        };
 
-        card.addEventListener("pointermove", (e) => {
-            if (!rect) rect = card.getBoundingClientRect();
-            const x = ((e.clientX - rect.left) / rect.width) * 100;
-            const y = ((e.clientY - rect.top) / rect.height) * 100;
-            pendingX = `${x}%`;
-            pendingY = `${y}%`;
-            if (!rafId) rafId = requestAnimationFrame(apply);
-        });
+        inView(
+            card,
+            () => {
+                inViewport = true;
+                startLoop();
+                return () => {
+                    inViewport = false;
+                    stopLoop();
+                };
+            },
+            { amount: 0.2 }
+        );
 
-        card.addEventListener("pointerleave", () => {
-            rect = null;
-            pendingX = "100%";
-            pendingY = "100%";
-            if (!rafId) rafId = requestAnimationFrame(apply);
-        });
+        if (supportsFinePointer) {
+            let rafId = 0;
+            let pendingX = "100%";
+            let pendingY = "100%";
+            let rect: DOMRect | null = null;
+
+            const apply = () => {
+                rafId = 0;
+                card.style.setProperty("--hero-mouse-x", pendingX);
+                card.style.setProperty("--hero-mouse-y", pendingY);
+            };
+
+            const releasePointer = () => {
+                pointerActive = false;
+                rect = null;
+                pendingX = "100%";
+                pendingY = "100%";
+                if (!rafId) rafId = requestAnimationFrame(apply);
+                if (inViewport) startLoop();
+            };
+
+            const pinRadius = () => {
+                if (pointerActive) {
+                    card.style.setProperty("--hero-mask-radius", "260px");
+                }
+            };
+
+            card.addEventListener("pointerenter", () => {
+                pointerActive = true;
+                stopLoop();
+                pinRadius();
+                requestAnimationFrame(pinRadius);
+                rect = card.getBoundingClientRect();
+            });
+
+            card.addEventListener("pointermove", (e) => {
+                if (!rect) rect = card.getBoundingClientRect();
+                const x = ((e.clientX - rect.left) / rect.width) * 100;
+                const y = ((e.clientY - rect.top) / rect.height) * 100;
+                pendingX = `${x}%`;
+                pendingY = `${y}%`;
+                if (!rafId) rafId = requestAnimationFrame(apply);
+            });
+
+            card.addEventListener("pointerleave", releasePointer);
+            card.addEventListener("pointercancel", releasePointer);
+        }
     }
 </script>


### PR DESCRIPTION
Promote the mask radius to --hero-mask-radius and drive a centered
breathing pulse (180px → 420px) via framer-motion when the hero is in
view. Pointer takeover suspends the loop, pins the radius to 260px
(re-applied next RAF to win over framer-motion's trailing frame), and
the loop resumes on pointerleave. Skipped under prefers-reduced-motion.