### PR TITLE
Refactor IMA Cloud case study: streamline content and update cover image

### DIFF
--- a/src/case-studies/ima-cloud.mdx
+++ b/src/case-studies/ima-cloud.mdx
@@ -1,7 +1,7 @@
 ---
 title: "IMA Cloud"
 subtitle: "Digitalización operativa para una empresa líder en electrificación ferroviaria"
-description: "Desarrollamos una plataforma interna para IMA Soluciones, enfocada en digitalizar reportes operativos, gestión documental e inventario."
+description: "Plataforma interna para una empresa de electrificación ferroviaria: reportes, almacén, inventario y equipos en un solo sistema."
 client: "IMA Soluciones"
 industry: "Electrificación ferroviaria, energía y telecomunicaciones"
 service: "Desarrollo de software a medida"
@@ -16,208 +16,113 @@ stack:
 featured: true
 pubDate: "2026-04-28"
 slug: "ima-cloud"
-cover: "/images/case-studies/ima-cloud/cover.webp"
+cover: "/case-studies/ima-cloud/dashboard.webp"
 ---
 
-## Digitalización operativa para una empresa líder en electrificación ferroviaria
+IMA Soluciones es una empresa mexicana con más de 20 años en electrificación ferroviaria, mantenimiento electromecánico y proyectos técnicos para los sectores de energía y telecomunicaciones. Su operación depende de documentación precisa: reportes de trabajo, entregas de almacén, evidencias y movimientos de inventario que tienen que mantenerse organizados entre equipos en oficina y en campo.
 
-IMA Cloud es una plataforma interna desarrollada para **IMA Soluciones**, una empresa mexicana especializada en electrificación ferroviaria, mantenimiento electromecánico, instalación, ingeniería, supervisión de obra, consultoría técnica y capacitación para los sectores de energía y telecomunicaciones.
+SYNC desarrolló **IMA Cloud**, una plataforma web interna que centraliza esos procesos. Reportes, almacén, inventario y gestión de equipos viven en el mismo sistema, accesible desde escritorio o desde el teléfono.
 
-Con más de 20 años de experiencia en el mercado, IMA participa en proyectos de alta exigencia técnica dentro y fuera de México. Su operación requiere coordinación entre equipos técnicos, documentación de actividades, control de reportes, seguimiento de mantenimiento y gestión de información relacionada con proyectos, personal, evidencias e inventario.
+![Panel general de IMA Cloud con reportes, módulos activos y actividad reciente](/case-studies/ima-cloud/dashboard.webp)
 
-SYNC desarrolló una plataforma web a la medida para centralizar procesos que antes dependían de documentos dispersos, formatos manuales y flujos operativos difíciles de consultar o escalar.
+## El contexto
 
----
+IMA trabaja en proyectos donde la trazabilidad importa: instalaciones, supervisión de obra, mantenimiento técnico. Cada actividad produce documentación que después tiene que consultarse, validarse o auditarse. Coordinar todo eso entre cuadrillas, almacenistas, supervisores y administradores requiere una base operativa común.
 
-## El reto
+## El problema
 
-IMA Soluciones opera en un sector donde la documentación, la trazabilidad y la disponibilidad de información son críticas.
+Antes de IMA Cloud, varios flujos dependían de formatos en papel, hojas sueltas y archivos repartidos entre carpetas locales y mensajes. Eso generaba fricción todos los días:
 
-Los procesos internos relacionados con reportes de trabajo, inventario, evidencias y documentación operativa requerían una forma más ordenada y digital de gestionarse.
-
-Antes de IMA Cloud, varios flujos dependían de herramientas aisladas o procesos manuales, lo que podía generar:
-
-- Captura repetitiva de información.
-- Dificultad para encontrar reportes históricos.
-- Archivos y evidencias distribuidos en distintos lugares.
-- Baja visibilidad sobre documentos operativos.
+- Captura repetitiva entre formatos.
+- Reportes históricos difíciles de encontrar.
+- Archivos y evidencias dispersos.
+- Baja visibilidad sobre el estado de la documentación.
 - Procesos difíciles de estandarizar entre áreas o proyectos.
-- Mayor carga administrativa para equipos técnicos y operativos.
+- Carga administrativa creciente para los equipos técnicos.
 
-El reto no era únicamente crear una aplicación web. Era construir una herramienta interna flexible que pudiera adaptarse a la forma real en la que IMA trabaja.
+El reto no era hacer una aplicación web genérica. Era construir una herramienta interna que se adaptara a cómo IMA ya trabaja, sin forzar a la empresa a cambiar su operación.
 
----
+## Lo que construimos
 
-## La solución
+IMA Cloud es una plataforma web a la medida que reúne, en un solo lugar, lo que antes vivía en herramientas aisladas:
 
-SYNC desarrolló **IMA Cloud**, una plataforma web interna diseñada para centralizar reportes operativos, documentación, inventario y gestión de archivos dentro de un solo sistema.
+- Reportes de trabajo y de almacén centralizados.
+- Plantillas dinámicas que guían el llenado por pasos.
+- Carpetas por equipo y subsistema para encontrar reportes en segundos.
+- Inventario conectado a las entregas de material.
+- Roles diferenciados para administradores, supervisores y almacenistas.
+- Acceso desde escritorio y desde mobile para equipos en campo.
 
-La solución fue construida a la medida para responder a las necesidades operativas de IMA, priorizando flexibilidad, velocidad de captura y organización de la información.
+La primera versión cubrió las necesidades inmediatas; la arquitectura se preparó para incorporar nuevos módulos sobre la misma base.
 
-IMA Cloud funciona como una base digital para transformar procesos manuales en flujos estructurados, consultables y escalables.
+## Capacidades
 
----
+### Reportes de trabajo y almacén
 
-## Funcionalidades principales
+Toda la documentación operativa se captura, se organiza y se consulta desde el mismo sistema, sin depender de quién guardó qué archivo.
 
-### Motor dinámico de reportes
+- Folios estandarizados por tipo y proyecto, del estilo `EQUIPO-DE-DISTRIBUCIÓN-DE-POTENCIA-DE-BAJO-VOLTAJE-2026-2` o `WAREHOUSE-2026-6`.
+- Navegación por carpetas según equipo o subsistema.
+- Búsqueda por folio, cliente, fecha o almacenista.
+- Filtros por turno y consulta de histórico.
 
-Uno de los componentes centrales de IMA Cloud es su sistema de reportes dinámicos.
+![Vista de reportes de almacén organizados por carpetas](/case-studies/ima-cloud/almacen.webp)
 
-En lugar de depender de formatos rígidos, la plataforma permite manejar estructuras flexibles para distintos tipos de reportes operativos.
+### Plantillas dinámicas
 
-Esto permite adaptar la captura de información a diferentes actividades, áreas o necesidades internas.
+En lugar de formatos rígidos, IMA Cloud usa plantillas que se adaptan al tipo de reporte. Quien llena el reporte avanza por pasos, viendo solo los campos que importan en cada etapa.
 
-**Capacidades principales:**
+- Estructura por secciones: datos generales, herramientas, refacciones.
+- Campos dinámicos según el subsistema o el tipo de entrega.
+- Validación por etapa antes de cerrar el reporte.
+- La misma plantilla para todos, sin reinventar formatos en cada proyecto.
 
-- Creación y llenado de reportes digitales.
-- Campos dinámicos según el tipo de reporte.
-- Organización de información por categorías o módulos.
-- Consulta de reportes históricos.
-- Reducción de dependencia de formatos físicos o archivos aislados.
+![Flujo de creación de un reporte de almacén por pasos](/case-studies/ima-cloud/nuevo-reporte.webp)
 
----
+### Roles e inventario
 
-### Gestión documental tipo Drive
+Cada usuario ve solo lo que le toca. Administradores, supervisores y almacenistas operan sobre la misma base de información, pero con permisos y acciones diferentes. El inventario está conectado directo a las entregas, así que lo que se entrega ya queda reflejado en el sistema.
 
-IMA Cloud integra un sistema de gestión documental que permite almacenar, organizar y consultar archivos internos desde una plataforma centralizada.
+- Roles diferenciados con permisos específicos.
+- Alta, edición, desactivación y reinicio de cuentas desde el panel de administración.
+- Inventario integrado al flujo de entregas y reportes.
+- Estado activo o inactivo por cuenta.
 
-Este módulo fue diseñado para funcionar como un repositorio interno de documentos y evidencias, reduciendo la dispersión de archivos entre carpetas locales, mensajes o herramientas externas.
+![Tabla de gestión de usuarios con roles de administrador, supervisor y almacenista](/case-studies/ima-cloud/usuarios.webp)
 
-**Capacidades principales:**
+### Operación desde el campo
 
-- Carga y organización de archivos.
-- Estructura de carpetas y documentos.
-- Centralización de evidencias operativas.
-- Asociación de archivos con procesos internos.
-- Consulta rápida de documentación relevante.
+IMA Cloud está pensado para usarse desde donde estén los equipos. La interfaz se adapta al teléfono, así que un almacenista o un técnico puede capturar reportes y consultar información sin depender de una computadora de oficina.
 
----
+![Panel general de IMA Cloud en mobile](/case-studies/ima-cloud/mobile.webp)
 
-### Control de inventario
-
-La plataforma también contempla funcionalidades relacionadas con inventario, permitiendo registrar y consultar recursos, materiales o elementos necesarios para la operación.
-
-Este módulo ayuda a conectar la información administrativa con la operación diaria.
-
-**Capacidades principales:**
-
-- Registro de elementos de inventario.
-- Consulta de existencias.
-- Organización de recursos operativos.
-- Base para trazabilidad de movimientos.
-- Integración con otros módulos de la plataforma.
-
----
-
-### Plataforma interna escalable
-
-IMA Cloud fue desarrollado como un sistema web interno, pensado para crecer conforme evolucionen los procesos de la empresa.
-
-La primera versión permitió resolver necesidades inmediatas de operación, mientras que la arquitectura se preparó para evolucionar hacia una estructura más modular y mantenible.
-
----
-
-## Desarrollo técnico
-
-Para construir IMA Cloud, SYNC utilizó tecnologías modernas orientadas a velocidad, flexibilidad y escalabilidad.
-
-### Frontend
-
-- Next.js
-- TypeScript
-- Tailwind CSS
-
-### Backend
-
-- Bun
-- TypeScript
-- Go
-
-### Base de datos
-
-- MongoDB
-- Postgresql
-
-### Arquitectura
-
-- Plataforma web modular.
-- Motor dinámico de plantillas.
-- Sistema documental personalizado.
-- Estructura adaptable para flujos operativos internos.
-
-La elección de MongoDB permitió manejar estructuras de reportes y documentos con mayor flexibilidad, especialmente para flujos donde los formatos pueden cambiar según el tipo de operación.
-
----
-
-## Proceso de trabajo
+## Cómo trabajamos
 
 ### 1. Diagnóstico
 
-Mapeamos cómo se generaban, almacenaban y consultaban reportes, documentación e inventario dentro de la operación de IMA.
-
-Identificamos qué partes del proceso podían digitalizarse sin forzar a la empresa a cambiar radicalmente su forma de trabajo, y diseñamos una estructura capaz de adaptarse a distintos tipos de reportes y documentos.
-
-Esto fue importante porque IMA opera en un entorno técnico donde cada proyecto o actividad puede requerir información distinta.
+Mapeamos cómo se generaban, almacenaban y consultaban los reportes, evidencias y movimientos de inventario dentro de IMA. Identificamos qué partes del proceso podían digitalizarse sin pedirle a la empresa que cambiara su forma de operar.
 
 ### 2. Desarrollo
 
-Construimos una primera versión funcional con un motor dinámico de plantillas para reportes, gestión documental tipo Drive y control inicial de inventario.
-
-Conforme el sistema comenzó a usarse, iteramos sobre feedback de uso real para mejorar la organización, la experiencia de usuario y la arquitectura.
-
-Esto permitió que IMA Cloud evolucionara de una primera solución funcional hacia una plataforma más sólida para la operación interna.
+Construimos una primera versión funcional con motor dinámico de plantillas, reportes por carpetas, inventario y gestión de usuarios. A partir del uso real, iteramos sobre lo que cada rol pedía mejorar.
 
 ### 3. Educación
 
-Acompañamos al equipo de IMA en la adopción del sistema y en la documentación de uso, dejando los flujos cubiertos por playbooks operativos y a SYNC como soporte y mantenimiento posterior.
-
----
-
-## Impacto
-
-IMA Cloud permitió a IMA Soluciones avanzar hacia una operación más digital, centralizada y trazable.
-
-La plataforma ayudó a reducir la dependencia de procesos manuales, ordenar la documentación interna y facilitar la consulta de información operativa.
-
-### Resultados principales
-
-- Reportes operativos consultables desde un solo sistema en lugar de archivos dispersos.
-- Captura de formatos internos en plantillas digitales dinámicas en lugar de documentos físicos.
-- Evidencias y documentos organizados en un repositorio interno, en lugar de carpetas locales o mensajes.
-- Consulta de información histórica desde la plataforma, sin depender de quién guardó qué archivo.
-- Arquitectura modular lista para incorporar nuevos procesos internos sobre la misma base.
-- Eliminación de capturas duplicadas entre áreas y de pasos manuales para mover información entre herramientas.
-
----
+Acompañamos al equipo de IMA en la adopción del sistema, dejamos los flujos cubiertos con playbooks operativos y nos quedamos como soporte y mantenimiento posterior.
 
 ## Antes y después
 
 | Antes | Después |
 | --- | --- |
 | Reportes manuales o dispersos | Reportes digitales centralizados |
-| Archivos en diferentes ubicaciones | Sistema documental interno |
-| Formatos rígidos | Plantillas dinámicas |
-| Consulta lenta de información histórica | Acceso organizado a reportes y documentos |
-| Inventario separado de la operación | Inventario integrado a la plataforma |
-| Procesos difíciles de escalar | Base digital modular y escalable |
+| Archivos en diferentes ubicaciones | Sistema interno consultable |
+| Formatos rígidos | Plantillas dinámicas por pasos |
+| Consulta lenta de información histórica | Búsqueda por folio, cliente o fecha |
+| Inventario separado de la operación | Inventario integrado al flujo de entregas |
+| Procesos difíciles de escalar | Base modular para sumar nuevos módulos |
 
----
+## Para empresas con operaciones complejas
 
-## Valor para el cliente
+Si tu equipo opera con reportes manuales, formatos físicos o evidencias repartidas entre herramientas, IMA Cloud es un ejemplo concreto de cómo se ve la salida.
 
-IMA Cloud no fue una página web genérica ni un sistema administrativo estándar.
-
-Fue una plataforma desarrollada alrededor de la operación real de una empresa técnica con procesos especializados.
-
-Para una empresa como IMA Soluciones, que trabaja en sectores donde la documentación, la precisión y la trazabilidad son relevantes, contar con una plataforma interna a la medida permite mejorar el control operativo y preparar la organización para seguir digitalizando procesos clave.
-
----
-
-## Conclusión
-
-En SYNC ayudamos a empresas con procesos complejos a convertir operaciones manuales en plataformas digitales a la medida.
-
-IMA Cloud es un ejemplo de cómo una solución personalizada puede centralizar reportes, documentos e inventario en un solo sistema, reduciendo fricción operativa y creando una base tecnológica escalable.
-
-No desarrollamos software genérico. Construimos herramientas alineadas a la forma en la que cada empresa realmente trabaja.
+En SYNC construimos plataformas internas alineadas a cómo cada empresa ya trabaja, no a cómo un sistema genérico cree que debería trabajar.

--- a/src/features/home/components/featured.astro
+++ b/src/features/home/components/featured.astro
@@ -13,7 +13,7 @@ const projects = [
         imageSrc: "/ima-cloud.webp",
         imageAlt: "IMA Cloud",
         projectName: "IMA Cloud",
-        description: "Automatización y gestión de formas.",
+        description: "Plataforma interna: reportes, almacén e inventario.",
         link: "/casos-de-estudio/ima-cloud",
     },
     {


### PR DESCRIPTION
## Summary
Significantly restructured and condensed the IMA Cloud case study to improve readability and focus. Replaced verbose explanations with concise, action-oriented prose aligned with SYNC's brand voice. Updated the cover image path and refreshed the featured project description.

## Key changes

- **Content restructuring**: Consolidated 200+ lines into ~110 lines by removing redundant sections and merging related concepts
  - Removed separate "El reto" and "La solución" sections; integrated problem/solution narrative into "El problema" and "Lo que construimos"
  - Collapsed verbose "Funcionalidades principales" subsections into a single "Capacidades" section with inline descriptions
  - Removed "Desarrollo técnico" and "Proceso de trabajo" detail sections; kept only essential "Cómo trabajamos" steps
  - Removed "Impacto" and "Valor para el cliente" sections; distilled insights into "Para empresas con operaciones complejas"

- **Voice and tone**: Rewrote opening paragraphs and throughout to match SYNC's "del lado nuestro" brand voice
  - Removed marketing jargon ("solución a la medida", "plataforma interna diseñada")
  - Replaced with direct, conversational language ("IMA Cloud es una plataforma web a la medida que reúne...")
  - Shortened sentences and removed filler phrases

- **Visual updates**:
  - Changed cover image from `/images/case-studies/ima-cloud/cover.webp` to `/case-studies/ima-cloud/dashboard.webp`
  - Added inline image references with alt text for dashboard, almacén, nuevo-reporte, usuarios, and mobile views

- **Featured project card**: Updated description from "Automatización y gestión de formas" to "Plataforma interna: reportes, almacén e inventario" for clarity

- **Before/After table**: Simplified and reordered rows for better narrative flow

## Implementation notes

- Maintained all frontmatter metadata (title, subtitle, client, industry, service, stack, featured status, pubDate, slug)
- Preserved semantic structure with H2 headings for major sections
- Kept the "Antes y después" comparison table as a key visual summary
- Removed technical stack details (Next.js, TypeScript, MongoDB, etc.) to focus on business value rather than implementation

https://claude.ai/code/session_0194VJxybz5djc7UBpizZSuu