### PR TITLE
feat(infraestructura): add vertical landing page for railway & infrastructure companies

### DIFF
--- a/src/features/infrastructure/components/infra-case.astro
+++ b/src/features/infrastructure/components/infra-case.astro
@@ -1,0 +1,62 @@
+---
+import "@app/styles/global.css";
+import { getEntry } from "astro:content";
+import Button from "@shared/components/ui/button.astro";
+import BulletList from "@shared/components/ui/bullet-list.astro";
+import EyebrowLabel from "@shared/components/ui/eyebrow-label.astro";
+
+const caseStudy = await getEntry("blog", "ima-cloud");
+
+const cover = caseStudy?.data.cover ?? "/case-studies/ima/dashboard.jpeg";
+const title = caseStudy?.data.title ?? "IMA Cloud";
+const client = caseStudy?.data.client ?? "IMA Soluciones";
+const industry =
+    caseStudy?.data.industry ??
+    "Electrificación ferroviaria, energía y telecomunicaciones";
+
+const outcomes = [
+    "Reportes operativos en un solo sistema, no en archivos dispersos.",
+    "Evidencias y documentos consultables desde cualquier área.",
+    "Inventario integrado a la operación, no como hoja de cálculo aparte.",
+    "Base modular lista para sumar nuevos procesos sin reinventar todo.",
+];
+---
+
+<section id="proyectos" class="container mx-auto py-24 md:py-32">
+    <div
+        class="grid grid-cols-1 lg:grid-cols-2 gap-8 md:gap-12 items-center rounded-2xl md:rounded-3xl border border-zinc-200 overflow-hidden bg-white"
+    >
+        <div class="relative bg-emerald-800 h-full min-h-[18rem] lg:min-h-[28rem]">
+            <img
+                src={cover}
+                alt={`Plataforma ${title} para ${client}`}
+                loading="lazy"
+                class="h-full w-full object-cover"
+            />
+        </div>
+
+        <div class="flex flex-col gap-6 p-8 sm:p-10 md:p-12 lg:pr-16">
+            <div class="flex flex-col gap-3">
+                <EyebrowLabel tone="emerald">Caso de estudio · {industry}</EyebrowLabel>
+                <h2
+                    class="text-2xl sm:text-3xl md:text-4xl font-semibold leading-tight tracking-tight text-zinc-900"
+                >
+                    {title} — digitalización operativa para una empresa de
+                    electrificación ferroviaria
+                </h2>
+                <p class="text-base md:text-lg text-zinc-600 leading-relaxed">
+                    {client} tenía más de 20 años de operación técnica con la
+                    información viviendo entre archivos sueltos. Construimos una
+                    plataforma interna alrededor de cómo el equipo realmente
+                    trabaja — y se quedó porque la operan todos los días.
+                </p>
+            </div>
+
+            <BulletList items={outcomes} />
+
+            <div class="flex flex-wrap items-center gap-3 pt-1">
+                <Button link="/casos-de-estudio/ima-cloud">Leer el caso completo</Button>
+            </div>
+        </div>
+    </div>
+</section>

--- a/src/features/infrastructure/components/infra-case.astro
+++ b/src/features/infrastructure/components/infra-case.astro
@@ -3,7 +3,6 @@ import "@app/styles/global.css";
 import { getEntry } from "astro:content";
 import Button from "@shared/components/ui/button.astro";
 import BulletList from "@shared/components/ui/bullet-list.astro";
-import EyebrowLabel from "@shared/components/ui/eyebrow-label.astro";
 
 const caseStudy = await getEntry("blog", "ima-cloud");
 
@@ -22,41 +21,115 @@ const outcomes = [
 ];
 ---
 
-<section id="proyectos" class="container mx-auto py-24 md:py-32">
+<section id="proyectos" class="container mx-auto py-16 md:py-24">
     <div
-        class="grid grid-cols-1 lg:grid-cols-2 gap-8 md:gap-12 items-center rounded-2xl md:rounded-3xl border border-zinc-200 overflow-hidden bg-white"
+        data-case-reveal
+        class="grid grid-cols-1 lg:grid-cols-2 items-stretch rounded-2xl md:rounded-3xl border border-zinc-200 overflow-hidden bg-white opacity-0"
     >
-        <div class="relative bg-emerald-800 h-full min-h-[18rem] lg:min-h-[28rem]">
+        <div class="relative bg-emerald-800 min-h-[18rem] lg:min-h-full">
             <img
                 src={cover}
                 alt={`Plataforma ${title} para ${client}`}
                 loading="lazy"
-                class="h-full w-full object-cover"
+                class="absolute inset-0 h-full w-full object-cover"
             />
         </div>
 
-        <div class="flex flex-col gap-6 p-8 sm:p-10 md:p-12 lg:pr-16">
-            <div class="flex flex-col gap-3">
-                <EyebrowLabel tone="emerald">Caso de estudio · {industry}</EyebrowLabel>
+        <div
+            class="relative isolate flex flex-col gap-6 p-8 sm:p-10 md:p-12 lg:p-14"
+        >
+            <div class="case-dots" aria-hidden="true"></div>
+            <div class="relative z-10 flex flex-col gap-3">
+                <span
+                    class="text-xs tracking-[0.2em] uppercase text-emerald-700 font-semibold"
+                >
+                    Caso de estudio
+                </span>
                 <h2
                     class="text-2xl sm:text-3xl md:text-4xl font-semibold leading-tight tracking-tight text-zinc-900"
                 >
-                    {title} — digitalización operativa para una empresa de
-                    electrificación ferroviaria
+                    {title} — digitalización operativa para una empresa
+                    ferroviaria
                 </h2>
+                <p class="text-sm text-zinc-500">{client} · {industry}</p>
                 <p class="text-base md:text-lg text-zinc-600 leading-relaxed">
-                    {client} tenía más de 20 años de operación técnica con la
-                    información viviendo entre archivos sueltos. Construimos una
-                    plataforma interna alrededor de cómo el equipo realmente
-                    trabaja — y se quedó porque la operan todos los días.
+                    Más de 20 años de operación técnica con la información
+                    viviendo entre archivos sueltos. Construimos una plataforma
+                    interna alrededor de cómo el equipo realmente trabaja — y se
+                    quedó porque la operan todos los días.
                 </p>
             </div>
 
-            <BulletList items={outcomes} />
+            <div class="relative z-10">
+                <BulletList items={outcomes} />
+            </div>
 
-            <div class="flex flex-wrap items-center gap-3 pt-1">
+            <div class="relative z-10 flex flex-wrap items-center gap-3 pt-1">
                 <Button link="/casos-de-estudio/ima-cloud">Leer el caso completo</Button>
             </div>
         </div>
     </div>
 </section>
+
+<style>
+    .case-dots {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        background-image: radial-gradient(
+            circle,
+            rgba(4, 120, 87, 0.7) 1.2px,
+            transparent 1.6px
+        );
+        background-size: 18px 18px;
+        opacity: 0.35;
+        mask-image: radial-gradient(
+            circle 220px at 100% 100%,
+            #000 0%,
+            transparent 75%
+        );
+        -webkit-mask-image: radial-gradient(
+            circle 220px at 100% 100%,
+            #000 0%,
+            transparent 75%
+        );
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        [data-case-reveal] {
+            opacity: 1 !important;
+        }
+    }
+</style>
+
+<script>
+    import { animate, inView } from "framer-motion";
+
+    const prefersReducedMotion = window.matchMedia(
+        "(prefers-reduced-motion: reduce)",
+    ).matches;
+
+    const card = document.querySelector<HTMLElement>("[data-case-reveal]");
+
+    if (card) {
+        if (prefersReducedMotion) {
+            card.style.opacity = "1";
+        } else {
+            inView(
+                card,
+                () => {
+                    animate(
+                        card,
+                        {
+                            opacity: [0, 1],
+                            transform: ["translateY(24px)", "translateY(0px)"],
+                        },
+                        { duration: 0.55, ease: [0.22, 1, 0.36, 1] },
+                    );
+                },
+                { amount: 0.25 },
+            );
+        }
+    }
+</script>

--- a/src/features/infrastructure/components/infra-challenges.astro
+++ b/src/features/infrastructure/components/infra-challenges.astro
@@ -1,9 +1,9 @@
 ---
 import "@app/styles/global.css";
-import SectionHeader from "@shared/components/ui/section-header.astro";
 import BulletList from "@shared/components/ui/bullet-list.astro";
 
 type Challenge = {
+    number: string;
     title: string;
     body: string;
     items: string[];
@@ -11,6 +11,7 @@ type Challenge = {
 
 const challenges: Challenge[] = [
     {
+        number: "01",
         title: "Documentación dispersa",
         body: "Evidencias, reportes y planos repartidos entre carpetas locales, mensajería interna y formatos en papel.",
         items: [
@@ -20,6 +21,7 @@ const challenges: Challenge[] = [
         ],
     },
     {
+        number: "02",
         title: "Operación en campo desconectada",
         body: "Cuadrillas y técnicos trabajando fuera de oficina, capturando en papel lo que luego alguien transcribe.",
         items: [
@@ -29,6 +31,7 @@ const challenges: Challenge[] = [
         ],
     },
     {
+        number: "03",
         title: "Decisiones sin datos a tiempo",
         body: "Inventario y avance de proyecto viviendo en hojas de cálculo separadas de la operación real.",
         items: [
@@ -41,24 +44,42 @@ const challenges: Challenge[] = [
 ---
 
 <section class="container mx-auto py-24 md:py-32">
-    <div class="mx-auto w-full max-w-3xl text-center mb-12 md:mb-16">
-        <SectionHeader
-            label="El reto del sector"
-            title="La operación está viva — la información, dispersa"
-            labelTone="emerald"
-        />
-        <p class="text-base sm:text-lg text-zinc-600 leading-relaxed -mt-4">
-            En electrificación ferroviaria, energía y telecomunicaciones, el
+    <header
+        class="max-w-3xl mx-auto flex flex-col gap-5 md:gap-6 text-center mb-12 md:mb-16"
+    >
+        <span
+            data-challenges-reveal
+            class="text-xs tracking-[0.2em] uppercase text-emerald-700 font-semibold opacity-0"
+        >
+            El reto del sector
+        </span>
+        <h2
+            data-challenges-reveal
+            class="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-semibold leading-tight md:leading-[1.15] tracking-tight text-zinc-800 opacity-0"
+        >
+            La operación está viva — la información, dispersa
+        </h2>
+        <p
+            data-challenges-reveal
+            class="text-base sm:text-lg md:text-xl text-zinc-600 leading-relaxed max-w-2xl mx-auto opacity-0"
+        >
+            En electrificación ferroviaria, energía y telecomunicaciones el
             trabajo técnico avanza más rápido que los sistemas que deberían
             sostenerlo. Estos son los cuellos de botella que vemos una y otra vez.
         </p>
-    </div>
+    </header>
 
     <div class="grid grid-cols-1 md:grid-cols-3 gap-5 md:gap-6">
         {
             challenges.map((challenge) => (
-                <article class="flex flex-col gap-5 p-8 md:p-10 rounded-3xl border border-zinc-200 bg-white">
+                <article
+                    data-challenges-card
+                    class="flex flex-col gap-6 p-8 md:p-10 rounded-3xl border border-zinc-200 bg-white opacity-0"
+                >
                     <div class="flex flex-col gap-3">
+                        <span class="text-sm font-semibold tracking-tight text-emerald-700">
+                            {challenge.number}
+                        </span>
                         <h3 class="text-xl md:text-2xl font-semibold tracking-tight text-zinc-900">
                             {challenge.title}
                         </h3>
@@ -66,9 +87,85 @@ const challenges: Challenge[] = [
                             {challenge.body}
                         </p>
                     </div>
-                    <BulletList items={challenge.items} />
+                    <div class="pt-1 border-t border-zinc-100">
+                        <div class="pt-5">
+                            <BulletList items={challenge.items} />
+                        </div>
+                    </div>
                 </article>
             ))
         }
     </div>
 </section>
+
+<style>
+    @media (prefers-reduced-motion: reduce) {
+        [data-challenges-reveal],
+        [data-challenges-card] {
+            opacity: 1 !important;
+        }
+    }
+</style>
+
+<script>
+    import { animate, inView, stagger } from "framer-motion";
+
+    const prefersReducedMotion = window.matchMedia(
+        "(prefers-reduced-motion: reduce)",
+    ).matches;
+
+    const reveals = document.querySelectorAll<HTMLElement>(
+        "[data-challenges-reveal]",
+    );
+    const cards = document.querySelectorAll<HTMLElement>(
+        "[data-challenges-card]",
+    );
+
+    const fadeIn = (el: HTMLElement, y = 18, duration = 0.6) => {
+        if (prefersReducedMotion) {
+            el.style.opacity = "1";
+            return;
+        }
+        inView(
+            el,
+            () => {
+                animate(
+                    el,
+                    {
+                        opacity: [0, 1],
+                        transform: [`translateY(${y}px)`, "translateY(0px)"],
+                    },
+                    { duration, ease: [0.22, 1, 0.36, 1] },
+                );
+            },
+            { amount: 0.4 },
+        );
+    };
+
+    reveals.forEach((el) => fadeIn(el));
+
+    if (cards.length) {
+        if (prefersReducedMotion) {
+            cards.forEach((el) => (el.style.opacity = "1"));
+        } else {
+            inView(
+                cards[0],
+                () => {
+                    animate(
+                        cards,
+                        {
+                            opacity: [0, 1],
+                            transform: ["translateY(24px)", "translateY(0px)"],
+                        },
+                        {
+                            duration: 0.55,
+                            ease: [0.22, 1, 0.36, 1],
+                            delay: stagger(0.09),
+                        },
+                    );
+                },
+                { amount: 0.25 },
+            );
+        }
+    }
+</script>

--- a/src/features/infrastructure/components/infra-challenges.astro
+++ b/src/features/infrastructure/components/infra-challenges.astro
@@ -1,0 +1,74 @@
+---
+import "@app/styles/global.css";
+import SectionHeader from "@shared/components/ui/section-header.astro";
+import BulletList from "@shared/components/ui/bullet-list.astro";
+
+type Challenge = {
+    title: string;
+    body: string;
+    items: string[];
+};
+
+const challenges: Challenge[] = [
+    {
+        title: "Documentación dispersa",
+        body: "Evidencias, reportes y planos repartidos entre carpetas locales, mensajería interna y formatos en papel.",
+        items: [
+            "Captura repetida entre áreas y proyectos",
+            "Historial difícil de encontrar cuando se necesita",
+            "Información que depende de quién la guardó",
+        ],
+    },
+    {
+        title: "Operación en campo desconectada",
+        body: "Cuadrillas y técnicos trabajando fuera de oficina, capturando en papel lo que luego alguien transcribe.",
+        items: [
+            "Doble captura entre campo y oficina",
+            "Reportes que llegan tarde a quien decide",
+            "Procesos imposibles de escalar al ritmo de la obra",
+        ],
+    },
+    {
+        title: "Decisiones sin datos a tiempo",
+        body: "Inventario y avance de proyecto viviendo en hojas de cálculo separadas de la operación real.",
+        items: [
+            "Inventario aparte de reportes y documentación",
+            "Avance de proyecto poco trazable",
+            "Sin visibilidad consolidada para planear",
+        ],
+    },
+];
+---
+
+<section class="container mx-auto py-24 md:py-32">
+    <div class="mx-auto w-full max-w-3xl text-center mb-12 md:mb-16">
+        <SectionHeader
+            label="El reto del sector"
+            title="La operación está viva — la información, dispersa"
+            labelTone="emerald"
+        />
+        <p class="text-base sm:text-lg text-zinc-600 leading-relaxed -mt-4">
+            En electrificación ferroviaria, energía y telecomunicaciones, el
+            trabajo técnico avanza más rápido que los sistemas que deberían
+            sostenerlo. Estos son los cuellos de botella que vemos una y otra vez.
+        </p>
+    </div>
+
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-5 md:gap-6">
+        {
+            challenges.map((challenge) => (
+                <article class="flex flex-col gap-5 p-8 md:p-10 rounded-3xl border border-zinc-200 bg-white">
+                    <div class="flex flex-col gap-3">
+                        <h3 class="text-xl md:text-2xl font-semibold tracking-tight text-zinc-900">
+                            {challenge.title}
+                        </h3>
+                        <p class="text-base leading-snug text-zinc-600">
+                            {challenge.body}
+                        </p>
+                    </div>
+                    <BulletList items={challenge.items} />
+                </article>
+            ))
+        }
+    </div>
+</section>

--- a/src/features/infrastructure/components/infra-faq.astro
+++ b/src/features/infrastructure/components/infra-faq.astro
@@ -1,0 +1,107 @@
+---
+import "@app/styles/global.css";
+import Button from "@shared/components/ui/button.astro";
+import FaqItem from "@shared/components/ui/faq-item.astro";
+import ArrowIcon from "@shared/components/ui/arrow-icon.astro";
+
+type Faq = {
+    q: string;
+    a: string;
+    link: { href: string; label: string };
+};
+
+const faqs: Faq[] = [
+    {
+        q: "¿Trabajan con equipos en campo y obra?",
+        a: "Sí. Diseñamos las herramientas alrededor de cómo trabajan las cuadrillas: captura digital en plantillas adaptadas a cada tipo de reporte, evidencias por proyecto y consulta desde cualquier dispositivo. La meta es eliminar la doble captura entre campo y oficina.",
+        link: { href: "/soluciones/desarrollo", label: "Ver Desarrollo" },
+    },
+    {
+        q: "¿Se integra con nuestros sistemas de inventario o ERP?",
+        a: "El Diagnóstico mapea qué sistemas ya usas y dónde se rompe el flujo. A partir de ahí construimos integraciones para que inventario, reportes y documentación vivan conectados a la operación, no en hojas de cálculo separadas.",
+        link: { href: "/soluciones/diagnostico", label: "Ver Diagnóstico" },
+    },
+    {
+        q: "¿Cómo manejan la documentación técnica y las evidencias?",
+        a: "Con un repositorio interno tipo Drive: carga y organización por carpetas, centralización de evidencias por proyecto y consulta rápida desde cualquier área. La documentación crítica deja de vivir entre carpetas locales y mensajería.",
+        link: { href: "/casos-de-estudio/ima-cloud", label: "Ver el caso IMA Cloud" },
+    },
+    {
+        q: "¿Quién mantiene y opera el sistema después?",
+        a: "Nosotros mantenemos el sistema en producción y tu equipo aprende a operarlo. El Plan de Acompañamiento mensual va incluido en la fase de Educación: talleres por rol, playbooks versionados y soporte continuo del lado nuestro.",
+        link: { href: "/soluciones/educacion", label: "Ver Educación" },
+    },
+    {
+        q: "¿Cuánto cuesta y cómo arranca un proyecto?",
+        a: "El monto exacto se cierra al final del Diagnóstico, con alcance acordado y precio fijo. El único punto de entrada es el Diagnóstico: sin entender la operación primero, cualquier propuesta es especulativa.",
+        link: { href: "/como-cobramos", label: "Ver cómo cobramos" },
+    },
+];
+
+const faqSchema = {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    mainEntity: faqs.map((f) => ({
+        "@type": "Question",
+        name: f.q,
+        acceptedAnswer: {
+            "@type": "Answer",
+            text: f.a,
+        },
+    })),
+};
+---
+
+<script is:inline type="application/ld+json" set:html={JSON.stringify(faqSchema)} />
+
+<section id="preguntas" class="container mx-auto py-24 md:py-32">
+    <div class="mx-auto w-full max-w-7xl flex flex-col gap-10 md:gap-14">
+        <header class="flex flex-col gap-3 max-w-2xl">
+            <span
+                class="text-xs tracking-[0.2em] text-emerald-700 font-semibold"
+            >
+                Preguntas frecuentes
+            </span>
+            <h2
+                class="text-2xl sm:text-3xl md:text-4xl font-semibold leading-tight tracking-tight text-zinc-800"
+            >
+                Lo que casi siempre preguntan en infraestructura
+            </h2>
+            <p class="text-base sm:text-lg text-zinc-600 leading-relaxed">
+                Respuestas breves a las dudas más recurrentes del sector. Cada
+                una enlaza a la página con el detalle completo.
+            </p>
+        </header>
+
+        <div class="flex flex-col gap-3">
+            {
+                faqs.map((faq) => (
+                    <FaqItem question={faq.q}>
+                        <div class="mt-4 flex flex-col gap-4">
+                            <p class="text-[15px] md:text-base leading-relaxed text-zinc-600">
+                                {faq.a}
+                            </p>
+                            <a
+                                href={faq.link.href}
+                                class="group/link inline-flex items-center gap-1.5 text-sm font-medium text-emerald-800 hover:text-emerald-900 self-start"
+                            >
+                                {faq.link.label}
+                                <ArrowIcon
+                                    size={14}
+                                    class="transition-transform group-hover/link:translate-x-0.5"
+                                />
+                            </a>
+                        </div>
+                    </FaqItem>
+                ))
+            }
+        </div>
+
+        <div
+            class="flex flex-wrap items-center gap-3 pt-4 border-t border-zinc-200"
+        >
+            <p class="text-sm text-zinc-600">¿Tu duda no está aquí?</p>
+            <Button variant="outline" link="/contacto">Escríbenos</Button>
+        </div>
+    </div>
+</section>

--- a/src/features/infrastructure/components/infra-hero.astro
+++ b/src/features/infrastructure/components/infra-hero.astro
@@ -1,0 +1,174 @@
+---
+import "@app/styles/global.css";
+import Button from "@shared/components/ui/button.astro";
+---
+
+<div
+    id="inicio"
+    class="pt-20 md:pt-20 pb-8 md:pb-12 container mx-auto flex justify-center items-center"
+>
+    <div
+        data-hero-card
+        class="hero-card relative isolate w-full min-h-[80vh] rounded-2xl md:rounded-3xl overflow-hidden border border-zinc-200 flex justify-center items-center px-6 sm:px-10 md:px-14 lg:px-20 py-20 md:py-24"
+    >
+    <div class="hero-dots hero-dots-active" aria-hidden="true"></div>
+    <div
+        class="flex flex-col gap-5 sm:gap-5 md:gap-6 lg:gap-7 w-full max-w-8xl lg:my-auto pt-0 lg:pt-20 relative z-10"
+    >
+        <div class="text-zinc-800 text-center md:text-start">
+            <span
+                class="text-xs tracking-[0.2em] text-emerald-700 font-semibold block mb-4"
+                >Para empresas de infraestructura y ferroviarias</span
+            >
+            <h1
+                class="text-[30px] sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-semibold mb-3 sm:mb-3 md:mb-4 leading-[1.15] md:leading-[1.1] px-0 sm:px-4 tracking-tight"
+            >
+                <span data-hero-line class="hero-line"
+                    >Software a medida para la operación <span
+                        class="font-[ibm-plex-serif] font-bold italic text-emerald-900 relative inline-block px-1.5 py-1 sm:px-3 sm:py-1.5 md:px-4 md:py-2"
+                        ><span
+                            class="absolute inset-0 bg-emerald-200/60 -rotate-1 transform origin-center rounded-sm -mx-1"
+                        ></span><span class="relative z-10">ferroviaria</span></span> y de infraestructura.</span
+                >
+            </h1>
+            <p
+                data-hero-line
+                class="hero-line text-base sm:text-base md:text-lg text-zinc-600 px-0 sm:px-4 max-w-3xl mx-auto md:mx-0 leading-snug"
+            >
+                Centralizamos reportes, documentación e inventario, conectamos a
+                tus equipos en campo y formamos al equipo para que opere el
+                sistema. La información deja de vivir entre archivos sueltos.
+            </p>
+        </div>
+
+        <div
+            data-hero-actions
+            class="flex flex-wrap justify-center md:justify-start gap-3 sm:gap-3 md:gap-4 w-full px-4 sm:px-0 hero-actions"
+        >
+            <Button link="/contacto" style="w-full sm:w-auto">Solicitar diagnóstico estratégico</Button>
+            <Button link="/#metodologia" variant="outline" style="w-full sm:w-auto">Conocer la metodología</Button>
+        </div>
+    </div>
+    </div>
+</div>
+
+<style>
+    .hero-card {
+        position: relative;
+    }
+
+    .hero-dots {
+        position: absolute;
+        inset: 0;
+        pointer-events: none;
+        z-index: 0;
+        background-image: radial-gradient(
+            circle,
+            rgba(4, 120, 87, 0.7) 0.9px,
+            transparent 1.2px
+        );
+        background-size: 13px 13px;
+    }
+
+    .hero-dots-active {
+        background-image: radial-gradient(
+            circle,
+            rgba(4, 120, 87, 0.6) 1px,
+            transparent 1.3px
+        );
+        background-size: 13px 13px;
+        mask-image: radial-gradient(
+            circle 480px at 100% 100%,
+            #000 0%,
+            rgba(0, 0, 0, 0.55) 35%,
+            rgba(0, 0, 0, 0.2) 80%,
+            transparent 100%
+        );
+        -webkit-mask-image: radial-gradient(
+            circle 480px at 100% 100%,
+            #000 0%,
+            rgba(0, 0, 0, 0.55) 35%,
+            rgba(0, 0, 0, 0.2) 80%,
+            transparent 100%
+        );
+    }
+
+    .hero-line {
+        display: block;
+    }
+
+    .hero-actions {
+        animation: hero-actions-in 0.76s cubic-bezier(0.22, 1, 0.36, 1) 0.35s both;
+    }
+
+    @keyframes hero-actions-in {
+        from { opacity: 0; transform: translateY(24px); }
+        to   { opacity: 1; transform: translateY(0); }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .hero-actions {
+            animation: none !important;
+            opacity: 1 !important;
+            transform: none !important;
+        }
+    }
+
+    @media (min-width: 640px) {
+        .hero-dots {
+            background-image: radial-gradient(
+                circle,
+                rgba(4, 120, 87, 0.7) 1.2px,
+                transparent 1.6px
+            );
+            background-size: 18px 18px;
+        }
+
+        .hero-dots-active {
+            background-image: radial-gradient(
+                circle,
+                rgba(4, 120, 87, 0.6) 1.3px,
+                transparent 1.7px
+            );
+            background-size: 18px 18px;
+        }
+    }
+
+    @media (min-width: 1024px) {
+        .hero-dots-active {
+            mask-image: radial-gradient(
+                circle 760px at 100% 100%,
+                #000 0%,
+                rgba(0, 0, 0, 0.55) 35%,
+                rgba(0, 0, 0, 0.2) 80%,
+                transparent 100%
+            );
+            -webkit-mask-image: radial-gradient(
+                circle 760px at 100% 100%,
+                #000 0%,
+                rgba(0, 0, 0, 0.55) 35%,
+                rgba(0, 0, 0, 0.2) 80%,
+                transparent 100%
+            );
+        }
+    }
+
+    @media (min-width: 1280px) {
+        .hero-dots-active {
+            mask-image: radial-gradient(
+                circle 980px at 100% 100%,
+                #000 0%,
+                rgba(0, 0, 0, 0.55) 35%,
+                rgba(0, 0, 0, 0.2) 80%,
+                transparent 100%
+            );
+            -webkit-mask-image: radial-gradient(
+                circle 980px at 100% 100%,
+                #000 0%,
+                rgba(0, 0, 0, 0.55) 35%,
+                rgba(0, 0, 0, 0.2) 80%,
+                transparent 100%
+            );
+        }
+    }
+</style>

--- a/src/features/infrastructure/components/infra-hero.astro
+++ b/src/features/infrastructure/components/infra-hero.astro
@@ -35,9 +35,9 @@ import Button from "@shared/components/ui/button.astro";
                 data-hero-line
                 class="hero-line text-base sm:text-base md:text-lg text-zinc-600 px-0 sm:px-4 max-w-3xl mx-auto md:mx-0 leading-snug"
             >
-                Centralizamos reportes, documentación e inventario, conectamos a
-                tus equipos en campo y formamos al equipo para que opere el
-                sistema. La información deja de vivir entre archivos sueltos.
+                Centralizamos reportes, documentación e inventario en un solo
+                sistema, diseñado alrededor de cómo tu equipo realmente trabaja.
+                La información deja de vivir entre archivos sueltos.
             </p>
         </div>
 

--- a/src/pages/infraestructura.astro
+++ b/src/pages/infraestructura.astro
@@ -1,0 +1,28 @@
+---
+export const prerender = true;
+
+import "@app/styles/global.css";
+import Layout from "@app/layouts/Layout.astro";
+import InfraHero from "@features/infrastructure/components/infra-hero.astro";
+import InfraChallenges from "@features/infrastructure/components/infra-challenges.astro";
+import InfraCase from "@features/infrastructure/components/infra-case.astro";
+import Workflow from "@features/home/components/workflow.astro";
+import Services from "@features/home/components/services.astro";
+import InfraFaq from "@features/infrastructure/components/infra-faq.astro";
+---
+
+<Layout
+    title="Software a medida para empresas de infraestructura y ferroviarias | Sync Estudio"
+    description="Digitalización operativa para electrificación ferroviaria, energía y telecomunicaciones. Centralizamos reportes, documentación e inventario, conectamos a tus equipos en campo y formamos a tu equipo — con mantenimiento del lado nuestro."
+    ogTitle="Software a medida para infraestructura y ferroviarias | Sync Estudio"
+    ogDescription="Centralizamos la operación de empresas de infraestructura: reportes, documentación e inventario en un solo sistema, diseñado alrededor de cómo tu equipo realmente trabaja."
+>
+    <div class="min-h-screen">
+        <InfraHero />
+        <InfraChallenges />
+        <InfraCase />
+        <Workflow />
+        <Services />
+        <InfraFaq />
+    </div>
+</Layout>


### PR DESCRIPTION
New prerendered route at /infraestructura targeting rail electrification,
energy and telecom operators. Reframes the three-phase offering around the
sector's operational pains and uses the IMA Cloud case study as proof.

- infra-hero: sector-specific hero reusing the homepage dot-overlay design
- infra-challenges: 3-card grid of sector pain points (SectionHeader + BulletList)
- infra-case: IMA Cloud proof block sourced from the blog content collection
- infra-faq: sector-specific FAQ with FAQPage JSON-LD
- reuses Workflow + Services and shared UI primitives verbatim

https://claude.ai/code/session_01HiyskcknZqG2m8YV1rCboq