### PR TITLE
feat(contact): add Cal.com popup booking to contact page

### DIFF
--- a/src/features/contact/components/contact.astro
+++ b/src/features/contact/components/contact.astro
@@ -1,6 +1,7 @@
 ---
 import "@app/styles/global.css";
 import Button from "@shared/components/ui/button.astro";
+import CalEmbed from "@shared/components/ui/cal-embed.astro";
 import { signTimestamp } from "@shared/utils/form-token";
 import { getLang, localizedPath } from "@i18n/utils";
 import { contact } from "@i18n/content/contact";
@@ -10,6 +11,7 @@ const copy = contact[lang];
 const pillars = copy.pillars;
 const pricingPath = localizedPath("pricing", lang);
 const whatsappHref = `https://wa.me/522228230805?text=${encodeURIComponent(copy.whatsappMessage)}`;
+const calLink = "yamil-yscapa/diagnostico-gratuito";
 
 // Strings the client-side script needs (validation, alerts, button states).
 const formI18n = {
@@ -357,6 +359,29 @@ const alreadySent = Astro.cookies.get("contact_sent")?.value === "1";
                                     : copy.submitLabel
                             }
                         </Button>
+                        <div class="mt-3">
+                            <CalEmbed
+                                calLink={calLink}
+                                namespace="diagnostico-gratuito"
+                                label={copy.bookingLabel}
+                                variant="outline"
+                                style="w-full"
+                            >
+                                <svg
+                                    xmlns="http://www.w3.org/2000/svg"
+                                    class="w-4 h-4"
+                                    fill="none"
+                                    viewBox="0 0 24 24"
+                                    stroke="currentColor"
+                                    stroke-width="2"
+                                    ><path
+                                        stroke-linecap="round"
+                                        stroke-linejoin="round"
+                                        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                                    ></path></svg
+                                >
+                            </CalEmbed>
+                        </div>
                         <div class="mt-4 text-center">
                             <Button
                                 variant="ghost"

--- a/src/i18n/content/contact.ts
+++ b/src/i18n/content/contact.ts
@@ -40,6 +40,7 @@ type ContactCopy = {
     submitLabel: string;
     alreadySentLabel: string;
     sendingLabel: string;
+    bookingLabel: string;
     whatsappLabel: string;
     whatsappMessage: string;
     /** Strings consumed by the client-side validation/submit script. */
@@ -116,6 +117,7 @@ export const contact: Record<Lang, ContactCopy> = {
         submitLabel: "Solicitar diagnóstico estratégico",
         alreadySentLabel: "Ya enviaste tu mensaje",
         sendingLabel: "Enviando...",
+        bookingLabel: "Agenda tu diagnóstico gratuito",
         whatsappLabel: "O envíanos un WhatsApp",
         whatsappMessage:
             "Hola, me gustaría saber más sobre sus servicios.",
@@ -212,6 +214,7 @@ export const contact: Record<Lang, ContactCopy> = {
         submitLabel: "Request strategic assessment",
         alreadySentLabel: "You already sent your message",
         sendingLabel: "Sending...",
+        bookingLabel: "Book your free assessment",
         whatsappLabel: "Or send us a WhatsApp",
         whatsappMessage: "Hi, I'd like to know more about your services.",
         validations: {

--- a/src/shared/components/ui/button.astro
+++ b/src/shared/components/ui/button.astro
@@ -5,6 +5,9 @@ interface Props {
     link?: string;
     blank?: boolean;
     disabled?: boolean;
+    id?: string;
+    /** Pass-through for data-* hooks (e.g. Cal.com popup triggers). */
+    [key: `data-${string}`]: string | undefined;
 }
 
 const {
@@ -13,6 +16,7 @@ const {
     link,
     blank = false,
     disabled = false,
+    ...rest
 } = Astro.props;
 
 const disabledClass = "disabled:opacity-50 disabled:cursor-not-allowed";
@@ -35,6 +39,7 @@ const variants = {
             href={link}
             class={`${style} ${variants[variant]}`}
             target={blank ? "_blank" : "_self"}
+            {...rest}
         >
             <slot />
         </a>
@@ -42,6 +47,7 @@ const variants = {
         <button
             class={`${style} ${variants[variant]} ${disabledClass}`}
             disabled={disabled}
+            {...rest}
         >
             <slot />
         </button>

--- a/src/shared/components/ui/cal-embed.astro
+++ b/src/shared/components/ui/cal-embed.astro
@@ -1,0 +1,83 @@
+---
+import Button from "@shared/components/ui/button.astro";
+
+interface Props {
+    /** Cal.com event path, e.g. "yamil-yscapa/diagnostico-gratuito". */
+    calLink: string;
+    /** Visible button label (rendered after any slotted icon). */
+    label: string;
+    variant?: "default" | "outline" | "ghost" | "small";
+    style?: string;
+    /**
+     * Cal namespace — must be unique per event link on a page. Defaults to a
+     * slug of the event so multiple embeds can coexist without colliding.
+     */
+    namespace?: string;
+}
+
+const {
+    calLink,
+    label,
+    variant = "outline",
+    style = "",
+    namespace = calLink.replace(/[^a-z0-9]+/gi, "-"),
+} = Astro.props;
+
+// Popup config + theming. Single emerald brand voltage per DESIGN.md.
+const calConfig = JSON.stringify({ layout: "month_view" });
+const calUi = {
+    cssVarsPerTheme: { light: { "cal-brand": "#1c5534" } },
+    hideEventTypeDetails: false,
+    layout: "month_view",
+};
+---
+
+<Button
+    variant={variant}
+    style={style}
+    data-cal-namespace={namespace}
+    data-cal-link={calLink}
+    data-cal-config={calConfig}
+>
+    <slot />{label}
+</Button>
+
+<script is:inline define:vars={{ namespace, calUi }}>
+    // Official Cal.com embed loader — lazy-injects embed.js on first call and
+    // is idempotent, so rendering this component more than once is safe.
+    (function (C, A, L) {
+        let p = function (a, ar) {
+            a.q.push(ar);
+        };
+        let d = C.document;
+        C.Cal =
+            C.Cal ||
+            function () {
+                let cal = C.Cal;
+                let ar = arguments;
+                if (!cal.loaded) {
+                    cal.ns = {};
+                    cal.q = cal.q || [];
+                    d.head.appendChild(d.createElement("script")).src = A;
+                    cal.loaded = true;
+                }
+                if (ar[0] === L) {
+                    const api = function () {
+                        p(api, arguments);
+                    };
+                    const namespace = ar[1];
+                    api.q = api.q || [];
+                    if (typeof namespace === "string") {
+                        cal.ns[namespace] = cal.ns[namespace] || api;
+                        p(cal.ns[namespace], ar);
+                        p(cal, ["initNamespace", namespace]);
+                    } else p(cal, ar);
+                    return;
+                }
+                p(cal, ar);
+            };
+    })(window, "https://app.cal.com/embed/embed.js", "init");
+
+    Cal("init", namespace, { origin: "https://app.cal.com" });
+    Cal.ns[namespace]("ui", calUi);
+</script>


### PR DESCRIPTION
Reusable cal-embed.astro wraps the official Cal popup snippet, themed
to the emerald brand voltage. Button now forwards data-* attributes so
the popup trigger reuses the shared primitive. Wires a "book your free
diagnostic" CTA into the contact form stack (es/en).

https://claude.ai/code/session_018EKHh3QEKQeyYfY24PRSwe