### PR TITLE
update(hero): book-a-call Cal CTA in hero and contact copy

### DIFF
--- a/src/features/home/components/hero.astro
+++ b/src/features/home/components/hero.astro
@@ -1,11 +1,15 @@
 ---
 import "@app/styles/global.css";
 import Button from "@shared/components/ui/button.astro";
+import CalEmbed from "@shared/components/ui/cal-embed.astro";
 import { getLang, localizedPath } from "@i18n/utils";
 import { home } from "@i18n/content/home";
 
 const lang = getLang(Astro.currentLocale);
 const copy = home[lang].hero;
+
+// Same booking event as the contact page — hero CTA opens the Cal popup.
+const calLink = "yamil-yscapa/diagnostico-gratuito";
 ---
 
 <div
@@ -40,7 +44,27 @@ const copy = home[lang].hero;
             data-hero-actions
             class="flex flex-wrap justify-center gap-3 sm:gap-3 md:gap-4 w-full px-4 sm:px-0 hero-actions"
         >
-            <Button link={localizedPath("contact", lang)} style="w-full sm:w-auto">{copy.ctaPrimary}</Button>
+            <CalEmbed
+                calLink={calLink}
+                namespace="diagnostico-hero"
+                label={copy.ctaPrimary}
+                variant="default"
+                style="w-full sm:w-auto"
+            >
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="w-4 h-4"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    ><path
+                        stroke-linecap="round"
+                        stroke-linejoin="round"
+                        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+                    ></path></svg
+                >
+            </CalEmbed>
             <Button link={localizedPath("howWeWork", lang)} variant="outline" style="w-full sm:w-auto">{copy.ctaSecondary}</Button>
         </div>
 

--- a/src/i18n/content/contact.ts
+++ b/src/i18n/content/contact.ts
@@ -117,7 +117,7 @@ export const contact: Record<Lang, ContactCopy> = {
         submitLabel: "Solicitar diagnóstico estratégico",
         alreadySentLabel: "Ya enviaste tu mensaje",
         sendingLabel: "Enviando...",
-        bookingLabel: "Agenda tu diagnóstico gratuito",
+        bookingLabel: "Agenda una llamada de diagnóstico",
         whatsappLabel: "O envíanos un WhatsApp",
         whatsappMessage:
             "Hola, me gustaría saber más sobre sus servicios.",
@@ -214,7 +214,7 @@ export const contact: Record<Lang, ContactCopy> = {
         submitLabel: "Request strategic assessment",
         alreadySentLabel: "You already sent your message",
         sendingLabel: "Sending...",
-        bookingLabel: "Book your free assessment",
+        bookingLabel: "Book a diagnostic call",
         whatsappLabel: "Or send us a WhatsApp",
         whatsappMessage: "Hi, I'd like to know more about your services.",
         validations: {

--- a/src/i18n/content/home.ts
+++ b/src/i18n/content/home.ts
@@ -90,7 +90,7 @@ export const home: Record<Lang, HomeCopy> = {
             titleTail: " de tu operación.",
             subtitle:
                 "Desarrollo de software, aplicaciones e inteligencia artificial a medida para empresas en operación. Quitamos el trabajo manual, desatascamos la operación y dejamos a tu equipo dueño del sistema.",
-            ctaPrimary: "Solicitar diagnóstico",
+            ctaPrimary: "Agenda una llamada",
             ctaSecondary: "Ver cómo trabajamos",
             locationTag: "Desde México · Disponibles en todo el mundo",
         },
@@ -253,7 +253,7 @@ export const home: Record<Lang, HomeCopy> = {
             titleTail: " of your operation.",
             subtitle:
                 "Custom software, applications and artificial intelligence for working companies. We remove manual work, unblock the operation, and leave your team owning the system.",
-            ctaPrimary: "Request an assessment",
+            ctaPrimary: "Book a call",
             ctaSecondary: "See how we work",
             locationTag: "Based in Mexico · Available worldwide",
         },

--- a/src/shared/components/ui/cal-embed.astro
+++ b/src/shared/components/ui/cal-embed.astro
@@ -80,4 +80,35 @@ const calUi = {
 
     Cal("init", namespace, { origin: "https://app.cal.com" });
     Cal.ns[namespace]("ui", calUi);
+
+    // Mobile zoom guard. The booking form lives in a cross-origin app.cal.com
+    // iframe whose input font-size we can't control, so iOS auto-zooms when a
+    // field is focused inside the popup. Lock maximum-scale=1 only while the
+    // Cal modal (<cal-modal-box>, appended to <body>) is open, then restore —
+    // so pinch-zoom stays available everywhere else. iOS-only on purpose: on
+    // Android, maximum-scale=1 would disable pinch-zoom outright. Runs once
+    // regardless of how many CalEmbed instances render on the page.
+    if (!window.__calZoomGuard) {
+        window.__calZoomGuard = true;
+        const ua = navigator.userAgent;
+        const isIOS =
+            /iP(hone|od|ad)/.test(ua) ||
+            (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1);
+        const viewport = document.querySelector('meta[name="viewport"]');
+        if (isIOS && viewport) {
+            const base = viewport.getAttribute("content");
+            const locked = base + ", maximum-scale=1";
+            let isLocked = false;
+            const sync = () => {
+                const open = !!document.querySelector("cal-modal-box");
+                if (open === isLocked) return;
+                isLocked = open;
+                viewport.setAttribute("content", open ? locked : base);
+            };
+            // Observe only <body>'s direct children: the modal box is appended
+            // there, and skipping the subtree avoids firing on the hero wave's
+            // per-frame text updates.
+            new MutationObserver(sync).observe(document.body, { childList: true });
+        }
+    }
 </script>


### PR DESCRIPTION
Switch hero primary CTA from a contact link to the Cal booking popup
("Agenda una llamada" / "Book a call"), reusing the diagnostico-gratuito
event. Update the contact booking label to "Agenda una llamada de
diagnóstico" / "Book a diagnostic call".