### PR TITLE
fix: P0 pre-outreach EN copy fixes

### DIFF
--- a/src/features/landing/data.ts
+++ b/src/features/landing/data.ts
@@ -146,7 +146,7 @@ export const landingEntries: LandingEntry[] = [
             en: {
                 metaTitle: "Custom software development | SYNC Estudio",
                 metaDescription:
-                    "Custom software development for working companies. Internal portals, dashboards, automations and integrations your team actually operates — with maintenance on our side. Based in Mexico, available worldwide.",
+                    "Custom software development for companies that run real operations. Internal portals, dashboards, automations and integrations your team actually operates — with maintenance on our side. Based in Mexico, available worldwide.",
                 label: "Software development",
                 title: "Custom software development",
                 highlight: "Custom",
@@ -308,7 +308,7 @@ export const landingEntries: LandingEntry[] = [
                 metaTitle:
                     "Web and mobile app development | SYNC Estudio",
                 metaDescription:
-                    "Custom web and mobile app development for working companies. Operational apps connected to your systems, operated by your team with autonomy and maintained by us. Based in Mexico, available worldwide.",
+                    "Custom web and mobile app development for companies that run real operations. Operational apps connected to your systems, operated by your team with autonomy and maintained by us. Based in Mexico, available worldwide.",
                 label: "App development",
                 title: "Custom app development",
                 highlight: "app",
@@ -465,7 +465,7 @@ export const landingEntries: LandingEntry[] = [
                 metaTitle:
                     "Applied artificial intelligence for companies | SYNC Estudio",
                 metaDescription:
-                    "Applied artificial intelligence for working companies: agents, copilots and LLMs integrated where they add value. No hype, with maintenance on our side. Based in Mexico, available worldwide.",
+                    "Applied artificial intelligence for companies that run real operations: agents, copilots and LLMs integrated where they add value. No hype, with maintenance on our side. Based in Mexico, available worldwide.",
                 label: "Artificial intelligence",
                 title: "Applied artificial intelligence for companies",
                 highlight: "Applied",

--- a/src/i18n/content/contact.ts
+++ b/src/i18n/content/contact.ts
@@ -214,7 +214,7 @@ export const contact: Record<Lang, ContactCopy> = {
         submitLabel: "Request strategic assessment",
         alreadySentLabel: "You already sent your message",
         sendingLabel: "Sending...",
-        bookingLabel: "Book a diagnostic call",
+        bookingLabel: "Book a discovery call",
         whatsappLabel: "Or send us a WhatsApp",
         whatsappMessage: "Hi, I'd like to know more about your services.",
         validations: {

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -222,7 +222,7 @@ export const ui = {
         "case.ctaSecondary": "Back to home",
         "case.titleSuffix": "Case study | Sync Estudio",
         "case.fallbackDescription":
-            "Sync Estudio case study — custom software and AI for working companies.",
+            "Sync Estudio case study — custom software and AI for companies that run real operations.",
     },
 } as const;
 

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -123,10 +123,10 @@ export const ui = {
         // Site meta defaults (Layout)
         "meta.title": "Custom software, apps & AI | SYNC Estudio",
         "meta.description":
-            "Custom software, applications and artificial intelligence for businesses in operation. Nearshore team based in Mexico, working U.S. hours, available worldwide. We redesign workflows, train your team, and keep the tools running on our side.",
+            "Custom software, applications and artificial intelligence for businesses in operation. Based in Mexico, working U.S. hours, available worldwide. We redesign workflows, train your team, and keep the tools running on our side.",
         "meta.ogTitle": "Custom software, apps & AI | SYNC Estudio",
         "meta.ogDescription":
-            "Custom software, applications and AI for businesses in operation. We build the tools, redesign the workflows, and train your team — with ongoing maintenance on our side. Nearshore from Mexico, available worldwide.",
+            "Custom software, applications and AI for businesses in operation. We build the tools, redesign the workflows, and train your team — with ongoing maintenance on our side. Based in Mexico, available worldwide.",
         "meta.ogImageAlt":
             "SYNC Estudio — Custom software & AI for companies in operation",
 

--- a/src/shared/seo/schema.ts
+++ b/src/shared/seo/schema.ts
@@ -17,12 +17,12 @@ const inLanguageOf = (lang: Lang): string => (lang === "en" ? "en-US" : "es-MX")
 
 const ORG_DESCRIPTION: Record<Lang, string> = {
     es: "Estudio de desarrollo de software, aplicaciones e inteligencia artificial a medida para empresas en operación. Desde México, disponibles en todo el mundo.",
-    en: "Custom software, application and artificial intelligence studio for working companies. Based in Mexico, available worldwide.",
+    en: "Custom software, application and artificial intelligence studio for companies that run real operations. Based in Mexico, available worldwide.",
 };
 
 const LOCAL_BUSINESS_DESCRIPTION: Record<Lang, string> = {
     es: "Desarrollo de software a medida, aplicaciones web y móviles, e inteligencia artificial aplicada para empresas en operación. Desde México, disponibles en todo el mundo.",
-    en: "Custom software development, web and mobile applications, and applied artificial intelligence for working companies. Based in Mexico, available worldwide.",
+    en: "Custom software development, web and mobile applications, and applied artificial intelligence for companies that run real operations. Based in Mexico, available worldwide.",
 };
 
 // JSON-LD nodes are loosely typed by nature (open vocabulary), so model


### PR DESCRIPTION
Per the P0 pre-outreach handoff — three surgical EN-only fixes, one commit each.

## Fix 1 — diagnostic call → discovery call
- Single instance: `src/i18n/content/contact.ts` EN `bookingLabel` ("Book a diagnostic call"). Fixed.
- Grep across EN tree found no other "diagnostic" in EN copy (remaining hits are Spanish "Diagnóstico/Diagnosticamos", untouched per spec).

## Fix 2 — nearshore removed from EN meta (root cause)
- **Root cause:** EN site-wide meta defaults in `src/i18n/ui.ts` — `meta.description` and `meta.ogDescription`. The Layout falls back to these on every EN page that doesn't pass its own description, which is why /en/contact and /en/case-studies/ima-cloud inherited "Nearshore from Mexico, available worldwide." Fixed at the source; all EN pages now inherit "Based in Mexico, available worldwide."
- Zero "nearshore" (case-insensitive) in src and in built dist output.

## Fix 3 — working companies → companies that run real operations
- 6 instances fixed: `src/features/landing/data.ts` (3 EN meta descriptions), `src/shared/seo/schema.ts` (2 EN JSON-LD descriptions), `src/i18n/ui.ts` (EN case-study fallback description).
- Zero "working companies" in src and dist. ES "empresas en operación" untouched.

## QA
- [x] `pnpm build` passes; only pre-existing Node `module.register()` deprecation warning, nothing new
- [x] dist grep: zero "nearshore", "working companies", "diagnostic call"
- [x] ES strings untouched — all replacements were English-only strings inside `en:` blocks
- [x] /en, /en/contact, /en/case-studies/ima-cloud meta + og:description verified: "Based in Mexico, available worldwide."
- [x] Cal embed renders one button (left the doubled trigger+label HTML alone per handoff note)

## Chose not to touch
- `meta.description` keeps "working U.S. hours" — handoff bans "nearshore" only; flagging in case you want it gone too.
- "businesses in operation" in the two ui.ts meta defaults left as-is — not a listed phrase and reads fine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)